### PR TITLE
基于IP的语言默认设置

### DIFF
--- a/glancy-site/package-lock.json
+++ b/glancy-site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "express": "^4.19.2",
+        "geoip-lite": "^1.4.10",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1"
@@ -1475,7 +1476,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1500,11 +1500,19 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -1550,7 +1558,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1588,6 +1595,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bytes": {
@@ -1663,7 +1679,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1680,7 +1695,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1693,14 +1707,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -2218,6 +2230,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.4.6",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
@@ -2335,6 +2356,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2367,6 +2394,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/geoip-lite": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.10.tgz",
+      "integrity": "sha512-4N69uhpS3KFd97m00wiFEefwa+L+HT5xZbzPhwu+sDawStg6UN/dPwWtUfkQuZkGIY1Cj7wDVp80IsqNtGMi2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "2.1 - 2.6.4",
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "rimraf": "2.5.2 - 2.7.1",
+        "yauzl": "2.9.2 - 2.10.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2404,6 +2449,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -2448,7 +2514,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2543,11 +2608,36 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -2608,6 +2698,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -2665,6 +2761,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -2694,6 +2799,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2785,7 +2896,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -2864,6 +2974,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -2948,6 +3067,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2962,6 +3090,12 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -3156,6 +3290,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/rollup": {
@@ -3414,6 +3561,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -3440,7 +3593,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -3670,12 +3822,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "express": "^4.19.2",
+    "geoip-lite": "^1.4.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.30.1"

--- a/glancy-site/server.js
+++ b/glancy-site/server.js
@@ -1,6 +1,7 @@
 import express from 'express'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import geoip from 'geoip-lite'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -9,6 +10,29 @@ const app = express()
 const port = process.env.PORT || 3000
 
 app.use(express.static(path.join(__dirname, 'dist')))
+
+app.set('trust proxy', true)
+
+app.get('/api/locale', (req, res) => {
+  const ip =
+    (req.headers['x-forwarded-for'] || '').split(',').shift() ||
+    req.socket?.remoteAddress ||
+    '127.0.0.1'
+  const geo = geoip.lookup(ip)
+  const country = geo?.country || 'US'
+  const map = {
+    CN: 'zh',
+    US: 'en',
+    GB: 'en',
+    DE: 'de',
+    FR: 'fr',
+    RU: 'ru',
+    JP: 'ja',
+    ES: 'es'
+  }
+  const lang = map[country] || 'en'
+  res.json({ country, lang })
+})
 
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'dist', 'index.html'))

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -2,15 +2,32 @@ import { BrowserRouter, Routes, Route, Link } from 'react-router-dom'
 import Home from './Home.jsx'
 import Login from './Login.jsx'
 import Portal from './Portal.jsx'
+import { LanguageProvider, useLanguage } from './LanguageContext.jsx'
+import { translations } from './translations.js'
 import './App.css'
 
+function Nav() {
+  const { t, setLang, lang } = useLanguage()
+  return (
+    <nav>
+      <Link to="/">{t.navHome}</Link> | <Link to="/login">{t.navLogin}</Link>
+      <select value={lang} onChange={(e) => setLang(e.target.value)}>
+        {Object.keys(translations).map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+    </nav>
+  )
+}
+
 function App() {
+  const { t } = useLanguage()
   return (
     <>
       <BrowserRouter>
-        <nav>
-          <Link to="/">首页</Link> | <Link to="/login">登录</Link>
-        </nav>
+        <Nav />
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
@@ -18,9 +35,8 @@ function App() {
         </Routes>
       </BrowserRouter>
       <div className="App">
-        <h1>Glancy 电子词典官网</h1>
-        <p>欢迎来到 Glancy，这是一个专注于词汇学习的电子词典。</p>
-        <Login />
+        <h1>{t.welcomeTitle}</h1>
+        <p>{t.welcomeMsg}</p>
       </div>
     </>
   )

--- a/glancy-site/src/Home.jsx
+++ b/glancy-site/src/Home.jsx
@@ -1,10 +1,12 @@
 import './App.css'
+import { useLanguage } from './LanguageContext.jsx'
 
 function Home() {
+  const { t } = useLanguage()
   return (
     <div className="App">
-      <h1>Glancy 电子词典官网</h1>
-      <p>欢迎来到 Glancy，这是一个专注于词汇学习的电子词典。</p>
+      <h1>{t.welcomeTitle}</h1>
+      <p>{t.welcomeMsg}</p>
     </div>
   )
 }

--- a/glancy-site/src/LanguageContext.jsx
+++ b/glancy-site/src/LanguageContext.jsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+import { translations } from './translations.js'
+
+const LanguageContext = createContext({
+  lang: 'en',
+  t: translations.en,
+  setLang: () => {}
+})
+
+export function LanguageProvider({ children }) {
+  const [lang, setLang] = useState('en')
+  const [t, setT] = useState(translations.en)
+
+  useEffect(() => {
+    fetch('/api/locale')
+      .then((res) => res.json())
+      .then((data) => {
+        if (translations[data.lang]) {
+          setLang(data.lang)
+          setT(translations[data.lang])
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  const changeLanguage = (l) => {
+    if (translations[l]) {
+      setLang(l)
+      setT(translations[l])
+    }
+  }
+
+  return (
+    <LanguageContext.Provider value={{ lang, t, setLang: changeLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useLanguage = () => useContext(LanguageContext)

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './App.css'
+import { useLanguage } from './LanguageContext.jsx'
 
 function Login() {
+  const { t } = useLanguage()
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [message, setMessage] = useState('')
@@ -19,10 +21,10 @@ function Login() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        throw new Error(text || '登录失败')
+        throw new Error(text || t.loginButton + '失败')
       }
       const data = await resp.json()
-      setMessage(`欢迎，${data.username}`)
+      setMessage(`${t.loginButton} ${data.username}`)
       if (data.username === 'admin') {
         navigate('/portal')
       } else {
@@ -35,10 +37,10 @@ function Login() {
 
   return (
     <div className="App">
-      <h2>用户登录</h2>
+      <h2>{t.loginTitle}</h2>
       <form onSubmit={handleSubmit}>
         <div>
-          <label htmlFor="username">用户名：</label>
+          <label htmlFor="username">{t.username}</label>
           <input
             id="username"
             value={username}
@@ -46,7 +48,7 @@ function Login() {
           />
         </div>
         <div>
-          <label htmlFor="password">密码：</label>
+          <label htmlFor="password">{t.password}</label>
           <input
             id="password"
             type="password"
@@ -54,7 +56,7 @@ function Login() {
             onChange={(e) => setPassword(e.target.value)}
           />
         </div>
-        <button type="submit">登录</button>
+        <button type="submit">{t.loginButton}</button>
         {message && <p>{message}</p>}
       </form>
     </div>

--- a/glancy-site/src/Portal.jsx
+++ b/glancy-site/src/Portal.jsx
@@ -1,10 +1,12 @@
 import './App.css'
+import { useLanguage } from './LanguageContext.jsx'
 
 function Portal() {
+  const { t } = useLanguage()
   return (
     <div className="App">
-      <h2>管理门户</h2>
-      <p>欢迎进入后台管理界面。</p>
+      <h2>{t.adminPortal}</h2>
+      <p>{t.adminWelcome}</p>
     </div>
   )
 }

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { LanguageProvider } from './LanguageContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </StrictMode>,
 )

--- a/glancy-site/src/translations.js
+++ b/glancy-site/src/translations.js
@@ -1,0 +1,86 @@
+export const translations = {
+  zh: {
+    navHome: '首页',
+    navLogin: '登录',
+    welcomeTitle: 'Glancy 电子词典官网',
+    welcomeMsg: '欢迎来到 Glancy，这是一个专注于词汇学习的电子词典。',
+    loginTitle: '用户登录',
+    username: '用户名：',
+    password: '密码：',
+    loginButton: '登录',
+    adminPortal: '管理门户',
+    adminWelcome: '欢迎进入后台管理界面。'
+  },
+  en: {
+    navHome: 'Home',
+    navLogin: 'Login',
+    welcomeTitle: 'Glancy Dictionary',
+    welcomeMsg: 'Welcome to Glancy, a dictionary focused on vocabulary learning.',
+    loginTitle: 'User Login',
+    username: 'Username:',
+    password: 'Password:',
+    loginButton: 'Login',
+    adminPortal: 'Admin Portal',
+    adminWelcome: 'Welcome to the administration page.'
+  },
+  de: {
+    navHome: 'Startseite',
+    navLogin: 'Anmelden',
+    welcomeTitle: 'Glancy Wörterbuch',
+    welcomeMsg: 'Willkommen bei Glancy, einem Wörterbuch für Vokabellernen.',
+    loginTitle: 'Benutzeranmeldung',
+    username: 'Benutzername:',
+    password: 'Passwort:',
+    loginButton: 'Anmelden',
+    adminPortal: 'Admin-Bereich',
+    adminWelcome: 'Willkommen im Administrationsbereich.'
+  },
+  fr: {
+    navHome: 'Accueil',
+    navLogin: 'Connexion',
+    welcomeTitle: 'Dictionnaire Glancy',
+    welcomeMsg: 'Bienvenue sur Glancy, un dictionnaire dédié à l\'apprentissage du vocabulaire.',
+    loginTitle: 'Connexion utilisateur',
+    username: 'Nom d\'utilisateur :',
+    password: 'Mot de passe :',
+    loginButton: 'Connexion',
+    adminPortal: 'Portail admin',
+    adminWelcome: 'Bienvenue sur la page d\'administration.'
+  },
+  ru: {
+    navHome: 'Главная',
+    navLogin: 'Вход',
+    welcomeTitle: 'Словарь Glancy',
+    welcomeMsg: 'Добро пожаловать в Glancy, словарь для изучения слов.',
+    loginTitle: 'Вход пользователя',
+    username: 'Имя пользователя:',
+    password: 'Пароль:',
+    loginButton: 'Войти',
+    adminPortal: 'Админ-портал',
+    adminWelcome: 'Добро пожаловать в административный раздел.'
+  },
+  ja: {
+    navHome: 'ホーム',
+    navLogin: 'ログイン',
+    welcomeTitle: 'Glancy 辞書',
+    welcomeMsg: '語彙学習に特化した Glancy へようこそ。',
+    loginTitle: 'ユーザーログイン',
+    username: 'ユーザー名：',
+    password: 'パスワード：',
+    loginButton: 'ログイン',
+    adminPortal: '管理ポータル',
+    adminWelcome: '管理ページへようこそ。'
+  },
+  es: {
+    navHome: 'Inicio',
+    navLogin: 'Iniciar sesión',
+    welcomeTitle: 'Diccionario Glancy',
+    welcomeMsg: 'Bienvenido a Glancy, un diccionario centrado en el aprendizaje de vocabulario.',
+    loginTitle: 'Inicio de sesión',
+    username: 'Usuario:',
+    password: 'Contraseña:',
+    loginButton: 'Entrar',
+    adminPortal: 'Portal de administración',
+    adminWelcome: 'Bienvenido a la página de administración.'
+  }
+}


### PR DESCRIPTION
## Summary
- add geoip-lite and locale API for IP based language detection
- provide translation text for seven languages
- add language context with automatic default from server
- update pages and navigation to support language switching

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873ac6798c88332aca5ac80fd0ed534