### PR TITLE
Add clear history feature

### DIFF
--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 
@@ -6,7 +6,14 @@ function Search() {
   const { t } = useLanguage()
   const [word, setWord] = useState('')
   const [result, setResult] = useState(null)
-  const [history, setHistory] = useState([])
+  const [history, setHistory] = useState(() => {
+    const stored = localStorage.getItem('searchHistory')
+    return stored ? JSON.parse(stored) : []
+  })
+
+  useEffect(() => {
+    localStorage.setItem('searchHistory', JSON.stringify(history))
+  }, [history])
 
   const handleSearch = async (e) => {
     e.preventDefault()
@@ -39,6 +46,7 @@ function Search() {
       {history.length > 0 && (
         <div>
           <h3>{t.searchHistory}</h3>
+          <button onClick={() => setHistory([])}>{t.clearHistory}</button>
           <ul>
             {history.map((h, i) => (
               <li key={i}>{h}</li>

--- a/glancy-site/src/translations.js
+++ b/glancy-site/src/translations.js
@@ -35,6 +35,7 @@ export const translations = {
     searchButton: '搜索',
     playAudio: '播放语音',
     searchHistory: '搜索记录',
+    clearHistory: '清空记录',
     notifications: '通知',
     markRead: '标为已读',
     faqTitle: '常见问题',
@@ -91,6 +92,7 @@ export const translations = {
     searchButton: 'Search',
     playAudio: 'Play',
     searchHistory: 'History',
+    clearHistory: 'Clear History',
     notifications: 'Notifications',
     markRead: 'Mark read',
     faqTitle: 'FAQ',
@@ -123,7 +125,8 @@ export const translations = {
     loginButton: 'Anmelden',
     adminLoginTitle: 'Admin-Login',
     adminPortal: 'Admin-Bereich',
-    adminWelcome: 'Willkommen im Administrationsbereich.'
+    adminWelcome: 'Willkommen im Administrationsbereich.',
+    clearHistory: 'Verlauf löschen'
   },
   fr: {
     navHome: 'Accueil',
@@ -137,7 +140,8 @@ export const translations = {
     loginButton: 'Connexion',
     adminLoginTitle: 'Connexion admin',
     adminPortal: 'Portail admin',
-    adminWelcome: 'Bienvenue sur la page d\'administration.'
+    adminWelcome: 'Bienvenue sur la page d\'administration.',
+    clearHistory: 'Effacer l\'historique'
   },
   ru: {
     navHome: 'Главная',
@@ -151,7 +155,8 @@ export const translations = {
     loginButton: 'Войти',
     adminLoginTitle: 'Вход администратора',
     adminPortal: 'Админ-портал',
-    adminWelcome: 'Добро пожаловать в административный раздел.'
+    adminWelcome: 'Добро пожаловать в административный раздел.',
+    clearHistory: 'Очистить историю'
   },
   ja: {
     navHome: 'ホーム',
@@ -165,7 +170,8 @@ export const translations = {
     loginButton: 'ログイン',
     adminLoginTitle: '管理者ログイン',
     adminPortal: '管理ポータル',
-    adminWelcome: '管理ページへようこそ。'
+    adminWelcome: '管理ページへようこそ。',
+    clearHistory: '履歴をクリア'
   },
   es: {
     navHome: 'Inicio',
@@ -179,6 +185,7 @@ export const translations = {
     loginButton: 'Entrar',
     adminLoginTitle: 'Acceso de administrador',
     adminPortal: 'Portal de administración',
-    adminWelcome: 'Bienvenido a la página de administración.'
+    adminWelcome: 'Bienvenido a la página de administración.',
+    clearHistory: 'Borrar historial'
   }
 }


### PR DESCRIPTION
## Summary
- persist search history across sessions
- add button to clear search history
- provide multilingual text for the new button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68789112e9bc8332b37a44a377efe694