### PR TITLE
[feature] add light dark theme

### DIFF
--- a/glancy-site/index.html
+++ b/glancy-site/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html lang="zh">
+<html lang="zh" data-theme="system">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link id="favicon" rel="icon" type="image/svg+xml" href="/src/assets/glancy-light.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>格律词典</title>
   </head>

--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -7,8 +7,8 @@
 
 /* General layout */
 .App {
-  background-color: #f5f5f5;
-  color: #333;
+  background-color: var(--app-bg);
+  color: var(--app-color);
   padding: 1rem;
   border-radius: 10px;
   margin-bottom: 1rem;

--- a/glancy-site/src/Chat.css
+++ b/glancy-site/src/Chat.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   height: 60vh;
   border: 1px solid #ccc;
-  background: #fafafa;
+  background: var(--chat-window-bg);
   border-radius: 10px;
 }
 
@@ -21,11 +21,11 @@
   max-width: 70%;
   padding: 0.5rem 1rem;
   border-radius: 12px;
-  background-color: #e0e0e0;
+  background-color: var(--chat-bubble-bg);
   align-self: flex-start;
 }
 
 .chat-bubble.user {
-  background-color: #d4e5ff;
+  background-color: var(--chat-bubble-user-bg);
   align-self: flex-end;
 }

--- a/glancy-site/src/Preferences.jsx
+++ b/glancy-site/src/Preferences.jsx
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { useTheme } from './ThemeContext.jsx'
 
 function Preferences() {
   const { t } = useLanguage()
+  const { theme, setTheme } = useTheme()
   const [language, setLanguage] = useState('en')
-  const [theme, setTheme] = useState('light')
   const [message, setMessage] = useState('')
 
   useEffect(() => {
@@ -13,10 +14,10 @@ function Preferences() {
       .then((res) => res.json())
       .then((data) => {
         setLanguage(data.language || 'en')
-        setTheme(data.theme || 'light')
+        setTheme(data.theme || 'system')
       })
       .catch(() => {})
-  }, [])
+  }, [setTheme])
 
   const handleSave = async (e) => {
     e.preventDefault()
@@ -38,7 +39,11 @@ function Preferences() {
         </div>
         <div>
           <label>{t.prefTheme}</label>
-          <input value={theme} onChange={(e) => setTheme(e.target.value)} />
+          <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+            <option value="light">light</option>
+            <option value="dark">dark</option>
+            <option value="system">system</option>
+          </select>
         </div>
         <button type="submit">{t.saveButton}</button>
       </form>

--- a/glancy-site/src/ThemeContext.jsx
+++ b/glancy-site/src/ThemeContext.jsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import lightIcon from './assets/glancy-light.svg'
+import darkIcon from './assets/glancy-dark.svg'
+
+const ThemeContext = createContext({
+  theme: 'system',
+  setTheme: () => {}
+})
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('system')
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) {
+      setTheme(stored)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('theme', theme)
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const apply = () => {
+      let current = theme
+      if (theme === 'system') {
+        current = media.matches ? 'dark' : 'light'
+      }
+      document.documentElement.dataset.theme = current
+      const link = document.getElementById('favicon')
+      if (link) {
+        link.href = current === 'dark' ? darkIcon : lightIcon
+      }
+    }
+    apply()
+    if (theme === 'system') {
+      media.addEventListener('change', apply)
+      return () => media.removeEventListener('change', apply)
+    }
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useTheme = () => useContext(ThemeContext)

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -3,14 +3,60 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+  --app-bg: #2c2c2c;
+  --app-color: rgba(255, 255, 255, 0.87);
+  --chat-window-bg: #333;
+  --chat-bubble-bg: #444;
+  --chat-bubble-user-bg: #2a5be2;
+}
+
+:root[data-theme='light'] {
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
+  --app-bg: #f5f5f5;
+  --app-color: #333;
+  --chat-window-bg: #fafafa;
+  --chat-bubble-bg: #e0e0e0;
+  --chat-bubble-user-bg: #d4e5ff;
+}
+
+:root[data-theme='system'] {
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme='system'] {
+    color: rgba(255, 255, 255, 0.87);
+    background-color: #242424;
+    --app-bg: #2c2c2c;
+    --app-color: rgba(255, 255, 255, 0.87);
+    --chat-window-bg: #333;
+    --chat-bubble-bg: #444;
+    --chat-bubble-user-bg: #2a5be2;
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  :root[data-theme='system'] {
+    color: #213547;
+    background-color: #ffffff;
+    --app-bg: #f5f5f5;
+    --app-color: #333;
+    --chat-window-bg: #fafafa;
+    --chat-bubble-bg: #e0e0e0;
+    --chat-bubble-user-bg: #d4e5ff;
+  }
 }
 
 a {
@@ -20,6 +66,10 @@ a {
 }
 a:hover {
   color: #535bf2;
+}
+
+:root[data-theme='light'] a:hover {
+  color: #747bff;
 }
 
 body {
@@ -54,15 +104,7 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+
+:root[data-theme='light'] button {
+  background-color: #f9f9f9;
 }

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import { LanguageProvider } from './LanguageContext.jsx'
+import { ThemeProvider } from './ThemeContext.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <LanguageProvider>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </LanguageProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
### Summary
- add theme context with system, light and dark handling
- switch favicon and data-theme according to user choice
- expose theme selection in Preferences
- update styles for light/dark modes
- bump patch version to 0.0.6

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6879132b2dc48332a55f8d013f9faf2c