### PR TITLE
[fix] integrate Chat styles

### DIFF
--- a/glancy-site/src/Chat.jsx
+++ b/glancy-site/src/Chat.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import './App.css'
+import './Chat.css'
 
 function Chat() {
   const [messages, setMessages] = useState([])
@@ -34,17 +35,17 @@ function Chat() {
   }, [messages, loading])
 
   return (
-    <div className="App">
-      <div
-        ref={listRef}
-        style={{ maxHeight: '60vh', overflowY: 'auto', textAlign: 'left' }}
-      >
+    <div className="chat-window">
+      <div className="chat-messages" ref={listRef}>
         {messages.map((m, i) => (
-          <p key={i}>
-            <strong>{m.from === 'user' ? 'You:' : 'Bot:'}</strong> {m.text}
-          </p>
+          <div
+            key={i}
+            className={`chat-bubble ${m.from === 'user' ? 'user' : ''}`}
+          >
+            {m.text}
+          </div>
         ))}
-        {loading && <p>...</p>}
+        {loading && <div className="chat-bubble">...</div>}
       </div>
       <form
         onSubmit={sendMessage}


### PR DESCRIPTION
### Summary
- apply chat style classes and import `Chat.css`

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687919b5f284833288cc6dd2ae273013