### PR TITLE
[feature] add interface components

### DIFF
--- a/glancy-site/src/Home.jsx
+++ b/glancy-site/src/Home.jsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import LanguageSelector from './components/Sidebar/LanguageSelector.jsx'
+import HistoryList from './components/Sidebar/HistoryList.jsx'
+import Favorites from './components/Sidebar/Favorites.jsx'
+import UserProfile from './components/Header/UserProfile.jsx'
+import SettingsMenu from './components/Header/SettingsMenu.jsx'
+import ViewModeToggle from './components/Header/ViewModeToggle.jsx'
+import ModelSelector from './components/Toolbar/ModelSelector.jsx'
+import VoiceInputButton from './components/Toolbar/VoiceInputButton.jsx'
+import ClearButton from './components/Toolbar/ClearButton.jsx'
 
 function Home() {
   const { t } = useLanguage()
@@ -19,8 +28,23 @@ function Home() {
 
   return (
     <div className="App">
+      <header>
+        <UserProfile />
+        <SettingsMenu />
+        <ViewModeToggle />
+      </header>
+      <aside>
+        <LanguageSelector />
+        <HistoryList />
+        <Favorites />
+      </aside>
       <p>{t.userCount}: {count}</p>
       <button onClick={refresh}>{t.refresh}</button>
+      <div className="toolbar">
+        <ModelSelector />
+        <VoiceInputButton />
+        <ClearButton onClear={() => setCount(0)} />
+      </div>
     </div>
   )
 }

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -1,0 +1,4 @@
+.header-section {
+  display: inline-block;
+  margin-right: 1rem;
+}

--- a/glancy-site/src/components/Header/SettingsMenu.jsx
+++ b/glancy-site/src/components/Header/SettingsMenu.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+import './Header.css'
+
+function SettingsMenu() {
+  return (
+    <div className="header-section">
+      <Link to="/preferences">Settings</Link>
+    </div>
+  )
+}
+
+export default SettingsMenu

--- a/glancy-site/src/components/Header/UserProfile.jsx
+++ b/glancy-site/src/components/Header/UserProfile.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import './Header.css'
+
+function UserProfile() {
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    fetch('/api/users/profile')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.username) {
+          setName(data.username)
+        }
+      })
+      .catch(() => {})
+  }, [])
+
+  return <div className="header-section">{name || 'Guest'}</div>
+}
+
+export default UserProfile

--- a/glancy-site/src/components/Header/ViewModeToggle.jsx
+++ b/glancy-site/src/components/Header/ViewModeToggle.jsx
@@ -1,0 +1,18 @@
+import { useTheme } from '../../ThemeContext.jsx'
+import './Header.css'
+
+function ViewModeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <div className="header-section">
+      <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </div>
+  )
+}
+
+export default ViewModeToggle

--- a/glancy-site/src/components/Sidebar/Favorites.jsx
+++ b/glancy-site/src/components/Sidebar/Favorites.jsx
@@ -1,0 +1,12 @@
+import './Sidebar.css'
+
+function Favorites() {
+  return (
+    <div className="sidebar-section">
+      <h3>Favorites</h3>
+      <p>No favorites yet.</p>
+    </div>
+  )
+}
+
+export default Favorites

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import './Sidebar.css'
+
+function HistoryList() {
+  const [history, setHistory] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('searchHistory')
+    if (stored) {
+      setHistory(JSON.parse(stored))
+    }
+  }, [])
+
+  if (history.length === 0) return null
+
+  return (
+    <div className="sidebar-section">
+      <h3>History</h3>
+      <ul>
+        {history.map((h, i) => (
+          <li key={i}>{h}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default HistoryList

--- a/glancy-site/src/components/Sidebar/LanguageSelector.jsx
+++ b/glancy-site/src/components/Sidebar/LanguageSelector.jsx
@@ -1,0 +1,21 @@
+import { translations } from '../../translations.js'
+import { useLanguage } from '../../LanguageContext.jsx'
+import './Sidebar.css'
+
+function LanguageSelector() {
+  const { lang, setLang } = useLanguage()
+
+  return (
+    <div className="sidebar-section">
+      <select value={lang} onChange={(e) => setLang(e.target.value)}>
+        {Object.keys(translations).map((l) => (
+          <option key={l} value={l}>
+            {l}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+export default LanguageSelector

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -1,0 +1,13 @@
+.sidebar-section {
+  margin-bottom: 1rem;
+}
+
+.sidebar-section ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sidebar-section select {
+  padding: 0.25rem;
+}

--- a/glancy-site/src/components/Toolbar/ClearButton.jsx
+++ b/glancy-site/src/components/Toolbar/ClearButton.jsx
@@ -1,0 +1,11 @@
+import './Toolbar.css'
+
+function ClearButton({ onClear }) {
+  return (
+    <button className="toolbar-section" onClick={onClear}>
+      Clear
+    </button>
+  )
+}
+
+export default ClearButton

--- a/glancy-site/src/components/Toolbar/ModelSelector.jsx
+++ b/glancy-site/src/components/Toolbar/ModelSelector.jsx
@@ -1,0 +1,17 @@
+import { useState } from 'react'
+import './Toolbar.css'
+
+function ModelSelector() {
+  const [model, setModel] = useState('model-a')
+
+  return (
+    <div className="toolbar-section">
+      <select value={model} onChange={(e) => setModel(e.target.value)}>
+        <option value="model-a">Model A</option>
+        <option value="model-b">Model B</option>
+      </select>
+    </div>
+  )
+}
+
+export default ModelSelector

--- a/glancy-site/src/components/Toolbar/Toolbar.css
+++ b/glancy-site/src/components/Toolbar/Toolbar.css
@@ -1,0 +1,3 @@
+.toolbar-section {
+  margin-right: 0.5rem;
+}

--- a/glancy-site/src/components/Toolbar/VoiceInputButton.jsx
+++ b/glancy-site/src/components/Toolbar/VoiceInputButton.jsx
@@ -1,0 +1,15 @@
+import './Toolbar.css'
+
+function VoiceInputButton() {
+  const handleClick = () => {
+    alert('Voice input not implemented')
+  }
+
+  return (
+    <button className="toolbar-section" onClick={handleClick}>
+      🎙️
+    </button>
+  )
+}
+
+export default VoiceInputButton


### PR DESCRIPTION
### Summary
- add Sidebar, Header, and Toolbar component directories
- implement new UI components and integrate them into Home page

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687919b570ac83328a2db07204378786