### PR TITLE
[fix] dedupe search history

### DIFF
--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -20,7 +20,10 @@ function Search() {
     e.preventDefault()
     const data = await fetchWord(word)
     setResult(data)
-    setHistory((h) => [word, ...h])
+    setHistory((h) => {
+      const unique = Array.from(new Set([word, ...h]))
+      return unique.slice(0, 20)
+    })
   }
 
   const playAudio = async () => {


### PR DESCRIPTION
### Summary
- prevent duplicates when storing search history
- keep only the latest 20 entries

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68791d3ab420833290cc4005654964ec