### PR TITLE
[fix] check api response

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -25,16 +25,16 @@ function Profile() {
     if (avatar) {
       formData.append('avatar', avatar)
     }
-    await fetch('/api/users/profile', {
+    const resp = await fetch('/api/users/profile', {
       method: 'POST',
       body: formData
     })
-    setMessage(t.updateSuccess)
+    setMessage(resp.ok ? t.updateSuccess : t.submitFail)
   }
 
   const handleBind = async () => {
-    await fetch('/api/bind/third-party')
-    setMessage(t.bindSuccess)
+    const resp = await fetch('/api/bind/third-party')
+    setMessage(resp.ok ? t.bindSuccess : t.submitFail)
   }
 
   return (


### PR DESCRIPTION
### Summary
- show failure messages when saving profile or binding account
- bump patch version to 0.0.8

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68791d372a688332b741ade108552105