### PR TITLE
[feature] add pro tag component with theme support

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.8",
+  "version": "0.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -15,11 +15,8 @@
   position: absolute;
   top: -4px;
   right: -8px;
-  background: #fff;
-  color: #000;
-  font-size: 0.6rem;
-  padding: 0 2px;
-  border-radius: 3px;
+  width: 24px;
+  height: auto;
 }
 .user-menu .menu {
   position: absolute;
@@ -53,11 +50,8 @@
   position: absolute;
   bottom: -4px;
   right: -4px;
-  background: #fff;
-  color: #000;
-  font-size: 0.5rem;
-  padding: 0 2px;
-  border-radius: 3px;
+  width: 20px;
+  height: auto;
 }
 .user-menu .email {
   color: gray;

--- a/glancy-site/src/components/Header/ProTag.jsx
+++ b/glancy-site/src/components/Header/ProTag.jsx
@@ -1,0 +1,14 @@
+import { useTheme } from '../../ThemeContext.jsx'
+import proLight from '../../assets/pro-tag-light.svg'
+import proDark from '../../assets/pro-tag-dark.svg'
+
+function ProTag({ small }) {
+  const { theme } = useTheme()
+  const current =
+    theme === 'system' ? document.documentElement.dataset.theme : theme
+  const src = current === 'dark' ? proDark : proLight
+  const className = small ? 'pro-tag-small' : 'pro-tag'
+  return <img src={src} className={className} alt="PRO" />
+}
+
+export default ProTag

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import './Header.css'
+import ProTag from './ProTag.jsx'
 
 function UserMenu() {
   const [open, setOpen] = useState(false)
@@ -10,14 +11,14 @@ function UserMenu() {
     <div className="header-section user-menu">
       <button onClick={() => setOpen(!open)}>
         <span role="img" aria-label="user">👤</span>
-        {isPro && <span className="pro-tag">PRO</span>}
+        {isPro && <ProTag />}
       </button>
       {open && (
         <div className="menu">
           <div className="menu-header">
             <div className="avatar">
               <span role="img" aria-label="user">👤</span>
-              {isPro && <span className="pro-tag-small">PRO</span>}
+              {isPro && <ProTag small />}
             </div>
             <div className="email">{email}</div>
           </div>


### PR DESCRIPTION
### Summary
- integrate ProTag component that uses SVG icons
- display PRO badge in user menu based on current theme

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6879278c3064833291efb8f5bb872179