### PR TITLE
[feature] add app branding to header

### DIFF
--- a/glancy-site/src/Home.jsx
+++ b/glancy-site/src/Home.jsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { useTheme } from './ThemeContext.jsx'
+import lightLogo from './assets/glancy-light.svg'
+import darkLogo from './assets/glancy-dark.svg'
 import LanguageSelector from './components/Sidebar/LanguageSelector.jsx'
 import HistoryList from './components/Sidebar/HistoryList.jsx'
 import Favorites from './components/Sidebar/Favorites.jsx'
@@ -11,8 +14,12 @@ import VoiceInputButton from './components/Toolbar/VoiceInputButton.jsx'
 import ClearButton from './components/Toolbar/ClearButton.jsx'
 
 function Home() {
-  const { t } = useLanguage()
+  const { t, lang } = useLanguage()
+  const { theme } = useTheme()
   const [count, setCount] = useState(0)
+  const current = theme === "system" ? document.documentElement.dataset.theme : theme
+  const logo = current === 'dark' ? darkLogo : lightLogo
+  const appName = lang === 'zh' ? '格律词典' : 'Glancy'
 
   const refresh = () => {
     fetch('/api/users/count')
@@ -27,9 +34,15 @@ function Home() {
 
   return (
     <div className="App">
-      <header>
-        <ViewModeToggle />
-        <UserMenu />
+      <header className="app-header">
+        <div className="app-brand">
+          <img src={logo} alt="logo" />
+          <span className="app-name">{appName}</span>
+        </div>
+        <div className="header-right">
+          <ViewModeToggle />
+          <UserMenu />
+        </div>
       </header>
       <aside>
         <LanguageSelector />

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -82,3 +82,25 @@
   border-top: 1px solid #ccc;
   padding-top: 0.5rem;
 }
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-brand {
+  display: flex;
+  align-items: center;
+}
+
+.app-brand img {
+  width: 32px;
+  height: 32px;
+  margin-right: 0.5rem;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+}


### PR DESCRIPTION
### Summary
- add theme-aware logo and language-based name in header
- align user menu to the right of the top bar

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68792dd209e08332a08ce559469b1c32