### PR TITLE
[feature] add sidebar brand

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -9,6 +9,22 @@
   color: #fff;
   padding: 20px;
 }
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  position: sticky;
+  top: 0;
+  background: inherit;
+  padding-bottom: 1rem;
+}
+.sidebar-brand img {
+  width: 32px;
+  height: 32px;
+  margin-right: 8px;
+}
+.sidebar-brand span {
+  font-size: 1.25rem;
+}
 
 .right {
   flex: 1;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import './App.css'
+import Brand from './components/Brand.jsx'
 
 function App() {
   const [text, setText] = useState('')
@@ -7,7 +8,7 @@ function App() {
   return (
     <div className="container">
       <aside className="sidebar">
-        <h2>Sidebar</h2>
+        <Brand />
       </aside>
       <div className="right">
         <header className="topbar">

--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -1,0 +1,19 @@
+import { useLanguage } from '../LanguageContext.jsx'
+import lightIcon from '../assets/glancy-light.svg'
+import darkIcon from '../assets/glancy-dark.svg'
+
+function Brand() {
+  const { lang } = useLanguage()
+  const hour = new Date().getHours()
+  const icon = hour >= 6 && hour < 18 ? lightIcon : darkIcon
+  const text = lang === 'zh' ? '格律词典' : 'Glancy'
+
+  return (
+    <div className="sidebar-brand">
+      <img src={icon} alt="Glancy" />
+      <span>{text}</span>
+    </div>
+  )
+}
+
+export default Brand


### PR DESCRIPTION
### Summary
- add sticky brand section with locale-based name
- select glancy-light or glancy-dark icon by time

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68793b2f772c83328ee62aba38a6fa74