### PR TITLE
[feature] implement default avatars

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import './App.css'
 import Brand from './components/Brand.jsx'
+import Avatar from './components/Avatar.jsx'
 
 function App() {
   const [text, setText] = useState('')
@@ -13,7 +14,7 @@ function App() {
       <div className="right">
         <header className="topbar">
           <div className="avatar">
-            <img src="https://via.placeholder.com/32" alt="avatar" />
+            <Avatar width={32} height={32} />
           </div>
         </header>
         <main className="display">Display Area</main>

--- a/glancy-site/src/components/Avatar.jsx
+++ b/glancy-site/src/components/Avatar.jsx
@@ -1,0 +1,14 @@
+import { useTheme } from '../ThemeContext.jsx'
+import avatarLight from '../assets/default-user-avatar-light.svg'
+import avatarDark from '../assets/default-user-avatar-dark.svg'
+
+// 基于当前主题切换默认头像
+function Avatar({ alt = 'User Avatar', ...props }) {
+  const { theme } = useTheme()
+  const current =
+    theme === 'system' ? document.documentElement.dataset.theme : theme
+  const src = current === 'dark' ? avatarDark : avatarLight
+  return <img src={src} alt={alt} {...props} />
+}
+
+export default Avatar

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import './Header.css'
 import ProTag from './ProTag.jsx'
+import Avatar from '../Avatar.jsx'
 
 function UserMenu() {
   const [open, setOpen] = useState(false)
@@ -10,14 +11,14 @@ function UserMenu() {
   return (
     <div className="header-section user-menu">
       <button onClick={() => setOpen(!open)}>
-        <span role="img" aria-label="user">👤</span>
+        <Avatar width={24} height={24} />
         {isPro && <ProTag />}
       </button>
       {open && (
         <div className="menu">
           <div className="menu-header">
             <div className="avatar">
-              <span role="img" aria-label="user">👤</span>
+              <Avatar width={32} height={32} />
               {isPro && <ProTag small />}
             </div>
             <div className="email">{email}</div>

--- a/glancy-site/src/components/Layout.jsx
+++ b/glancy-site/src/components/Layout.jsx
@@ -1,5 +1,6 @@
 import { Outlet } from 'react-router-dom'
 import './Layout.css'
+import Avatar from './Avatar.jsx'
 
 function Layout() {
   return (
@@ -27,7 +28,7 @@ function Layout() {
       <main className="main">
         <div className="avatar-wrapper">
           <div className="avatar">
-            <img src="https://via.placeholder.com/36" alt="User Avatar" />
+            <Avatar />
           </div>
           <div className="plus-badge">PLUS</div>
         </div>


### PR DESCRIPTION
### Summary
- add Avatar component to switch images based on theme
- replace placeholder avatars in the layout, app and menu
- bump patch version to 0.0.15

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6879426f51c48332b778bcd0b24f7bc7