### PR TITLE
[fix] add corner radius to chat input

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -24,6 +24,7 @@ function App() {
             placeholder="Word, Phrase or Sentence"
             value={text}
             onChange={(e) => setText(e.target.value)}
+            style={{ borderRadius: '20px' }}
           />
           <button>{text.trim() === '' ? '🎤' : '➤'}</button>
         </div>


### PR DESCRIPTION
### Summary
- add inline border radius style for chat input
- bump package patch version

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68794b9823788332baeed6368cbf43a9