### PR TITLE
[feature] use theme-based icons

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -72,9 +72,17 @@
 }
 
 .chatbox button {
-  margin-left: 10px;
   border: none;
   background: none;
-  font-size: 20px;
+  padding: 0;
   cursor: pointer;
+}
+
+.chatbox button + button {
+  margin-left: 10px;
+}
+
+.chatbox button img {
+  width: 24px;
+  height: 24px;
 }

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -1,10 +1,20 @@
 import { useState } from 'react'
+import { useTheme } from './ThemeContext.jsx'
+import sendLight from './assets/send-button-light.svg'
+import sendDark from './assets/send-button-dark.svg'
+import voiceLight from './assets/voice-button-light.svg'
+import voiceDark from './assets/voice-button-dark.svg'
 import './App.css'
 import Brand from './components/Brand.jsx'
 import Avatar from './components/Avatar.jsx'
 
 function App() {
   const [text, setText] = useState('')
+  const { theme } = useTheme()
+  const current =
+    theme === 'system' ? document.documentElement.dataset.theme : theme
+  const sendIcon = current === 'dark' ? sendDark : sendLight
+  const voiceIcon = current === 'dark' ? voiceDark : voiceLight
 
   return (
     <div className="container">
@@ -25,7 +35,12 @@ function App() {
             value={text}
             onChange={(e) => setText(e.target.value)}
           />
-          <button>{text.trim() === '' ? '🎤' : '➤'}</button>
+          <button>
+            <img
+              src={text.trim() === '' ? voiceIcon : sendIcon}
+              alt={text.trim() === '' ? 'voice' : 'send'}
+            />
+          </button>
         </div>
       </div>
     </div>

--- a/glancy-site/src/Chat.css
+++ b/glancy-site/src/Chat.css
@@ -47,5 +47,16 @@
 }
 
 .chat-input button {
+  border: none;
+  background: none;
+  padding: 0;
+}
+
+.chat-input button + button {
   margin-left: 0.5rem;
+}
+
+.chat-input button img {
+  width: 24px;
+  height: 24px;
 }

--- a/glancy-site/src/Chat.jsx
+++ b/glancy-site/src/Chat.jsx
@@ -1,11 +1,21 @@
 import { useState, useRef, useEffect } from 'react'
 import './App.css'
 import { sendChatMessage } from './api/chat.js'
+import { useTheme } from './ThemeContext.jsx'
+import sendLight from './assets/send-button-light.svg'
+import sendDark from './assets/send-button-dark.svg'
+import voiceLight from './assets/voice-button-light.svg'
+import voiceDark from './assets/voice-button-dark.svg'
 
 function Chat() {
   const [messages, setMessages] = useState([])
   const [text, setText] = useState('')
   const [loading, setLoading] = useState(false)
+  const { theme } = useTheme()
+  const current =
+    theme === 'system' ? document.documentElement.dataset.theme : theme
+  const sendIcon = current === 'dark' ? sendDark : sendLight
+  const voiceIcon = current === 'dark' ? voiceDark : voiceLight
   const listRef = useRef(null)
 
   const sendMessage = async (e) => {
@@ -47,7 +57,12 @@ function Chat() {
           value={text}
           onChange={(e) => setText(e.target.value)}
         />
-        <button type="submit">Send</button>
+        <button type="submit">
+          <img
+            src={text.trim() === '' ? voiceIcon : sendIcon}
+            alt={text.trim() === '' ? 'voice' : 'send'}
+          />
+        </button>
       </form>
     </div>
   )


### PR DESCRIPTION
### Summary
- switch chatbox icons to theme-specific SVGs
- update CSS for new image buttons

### Testing
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_68794b4b555c8332ad168f048db72993