### PR TITLE
[fix] reposition pro tag

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -13,8 +13,9 @@
 }
 .user-menu .pro-tag {
   position: absolute;
-  top: -4px;
-  right: -8px;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
   width: 24px;
   height: auto;
 }


### PR DESCRIPTION
### Summary
- repositioned pro tag under the avatar icon with overlap
- bump patch version to 0.0.19

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68794eb6ec5c8332972383d955eb98d9