### PR TITLE
[fix] remove button focus outline

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -116,7 +116,7 @@ button:hover {
 }
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: none;
 }
 
 


### PR DESCRIPTION
### Summary
- remove default outline on button focus to hide blue border
- bump patch version to 0.0.21

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687952afc3b0833298183d256b8cc479