### PR TITLE
[fix] adjust mobile viewport height

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Layout.css
+++ b/glancy-site/src/components/Layout.css
@@ -7,7 +7,7 @@ body {
 
 .app-container {
   display: flex;
-  min-height: 100vh;
+  min-height: var(--vh);
 }
 
 .sidebar {

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -88,11 +88,11 @@ a:hover {
 body {
   margin: 0;
   min-width: 320px;
-  min-height: 100vh;
+  min-height: var(--vh);
 }
 
 #root {
-  min-height: 100vh;
+  min-height: var(--vh);
 }
 
 h1 {


### PR DESCRIPTION
### Summary
- use `var(--vh)` for body and root heights
- fix layout height to rely on `--vh`
- bump patch version to 0.0.24

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879d5ff5ad08332b3754a314cc6b458