### PR TITLE
[feature] move user menu to sidebar

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -10,6 +10,8 @@
   background: #000;
   color: #fff;
   padding: 20px;
+  display: flex;
+  flex-direction: column;
 }
 .sidebar-brand {
   display: flex;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -6,7 +6,7 @@ import voiceLight from './assets/voice-button-light.svg'
 import voiceDark from './assets/voice-button-dark.svg'
 import './App.css'
 import Brand from './components/Brand.jsx'
-import UserMenu from './components/Header/UserMenu.jsx'
+import SidebarUser from './components/Sidebar/SidebarUser.jsx'
 
 function App() {
   const [text, setText] = useState('')
@@ -18,11 +18,10 @@ function App() {
     <div className="container">
       <aside className="sidebar">
         <Brand />
+        <SidebarUser />
       </aside>
       <div className="right">
-        <header className="topbar">
-          <UserMenu size={32} />
-        </header>
+        <header className="topbar"></header>
         <main className="display">What are we querying next?</main>
         <div className="chatbox">
           <input

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -11,6 +11,14 @@
   cursor: pointer;
   position: relative;
 }
+.user-menu button.with-name {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.user-menu .username {
+  margin-left: 0.5rem;
+}
 .user-menu .pro-tag {
   position: absolute;
   bottom: -6px;

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -5,7 +5,7 @@ import Avatar from '../Avatar.jsx'
 
 // size 控制触发按钮中头像的尺寸
 
-function UserMenu({ size = 24 }) {
+function UserMenu({ size = 24, showName = false }) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
   const email = 'user@example.com'
@@ -25,9 +25,10 @@ function UserMenu({ size = 24 }) {
 
   return (
     <div className="header-section user-menu" ref={menuRef}>
-      <button onClick={() => setOpen(!open)}>
+      <button onClick={() => setOpen(!open)} className={showName ? 'with-name' : ''}>
         <Avatar width={size} height={size} />
         {isPro && <ProTag />}
+        {showName && <span className="username">{email}</span>}
       </button>
       {open && (
         <div className="menu">

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -11,3 +11,10 @@
 .sidebar-section select {
   padding: 0.25rem;
 }
+
+.sidebar-user {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}

--- a/glancy-site/src/components/Sidebar/SidebarUser.jsx
+++ b/glancy-site/src/components/Sidebar/SidebarUser.jsx
@@ -1,0 +1,12 @@
+import UserMenu from '../Header/UserMenu.jsx'
+import './Sidebar.css'
+
+function SidebarUser() {
+  return (
+    <div className="sidebar-user">
+      <UserMenu size={32} showName />
+    </div>
+  )
+}
+
+export default SidebarUser


### PR DESCRIPTION
### Summary
- add SidebarUser component to display user avatar at sidebar bottom
- support showing username in UserMenu component
- remove topbar user menu and adjust layout styles
- bump version to 0.0.24

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879d7396ae88332ac055e25d3936b93