### PR TITLE
[fix] disable overscroll on display area

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -58,6 +58,7 @@
   align-items: center;
   padding: 20px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   font-size: 2rem;
   font-weight: bold;
   text-align: center;


### PR DESCRIPTION
### Summary
- prevent contentless display area from scrolling
- bump version to 0.0.25

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879da2c77348332bd8a9b64f38e0a49