### PR TITLE
[fix] adjust sidebar user menu style

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.25",
+  "version": "0.0.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -10,6 +10,8 @@
   border: none;
   cursor: pointer;
   position: relative;
+  padding: 0;
+  border-radius: 0;
 }
 .user-menu button.with-name {
   display: flex;

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -32,3 +32,8 @@
   padding: 8px 0;
   color: inherit;
 }
+
+.sidebar-user .user-menu button.with-name:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}


### PR DESCRIPTION
### Summary
- remove button padding from `UserMenu` for seamless appearance
- highlight sidebar user menu on hover
- bump version to 0.0.26

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6879e03a33cc8332923214331c8eaf22