### PR TITLE
[refactor] centralize API paths

### DIFF
--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -1,0 +1,22 @@
+# Code Refactor Plan
+
+This document tracks current cleanup efforts and future improvements.
+
+## Analysis
+- Several components used hard-coded API paths. This makes future maintenance
+  error-prone.
+- Version increments require manual updates after merges.
+- There is no unified API client for server requests.
+
+## Completed Tasks
+1. Added missing entries in `API_PATHS` so all endpoints are centralized.
+2. Updated components to reference these constants instead of literal strings.
+3. Bumped patch version in `package.json`.
+
+## Future Work
+- Introduce a small API client or React hook to wrap `fetch` calls. This allows
+  error handling and authentication logic to be reused.
+- Apply design patterns such as the **Facade** pattern for API access and the
+  **Context** pattern for global app state.
+- Remove unused components and consolidate styles to reduce duplication.
+

--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/AdminLogin.jsx
+++ b/glancy-site/src/AdminLogin.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function AdminLogin() {
   const { t } = useLanguage()
@@ -14,7 +15,7 @@ function AdminLogin() {
     e.preventDefault()
     setMessage('')
     try {
-      const resp = await fetch('/api/admin/login', {
+      const resp = await fetch(API_PATHS.adminLogin, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/glancy-site/src/Contact.jsx
+++ b/glancy-site/src/Contact.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Contact() {
   const { t } = useLanguage()
@@ -11,7 +12,7 @@ function Contact() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const resp = await fetch('/api/contact', {
+    const resp = await fetch(API_PATHS.contact, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, email, message: msg })

--- a/glancy-site/src/Faq.jsx
+++ b/glancy-site/src/Faq.jsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Faq() {
   const { t } = useLanguage()
   const [items, setItems] = useState([])
 
   useEffect(() => {
-    fetch('/api/faqs')
+    fetch(API_PATHS.faqs)
       .then((res) => res.json())
       .then((data) => setItems(data))
       .catch(() => {})

--- a/glancy-site/src/Health.jsx
+++ b/glancy-site/src/Health.jsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useCallback } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Health() {
   const { t } = useLanguage()
   const [status, setStatus] = useState('')
 
   const check = useCallback(() => {
-    fetch('/api/ping')
+    fetch(API_PATHS.ping)
       .then((res) => setStatus(res.ok ? t.ok : t.fail))
       .catch(() => setStatus(t.fail))
   }, [t])

--- a/glancy-site/src/LanguageContext.jsx
+++ b/glancy-site/src/LanguageContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { translations } from './translations.js'
+import { API_PATHS } from './config/api.js'
 
 const LanguageContext = createContext({
   lang: 'zh',
@@ -12,7 +13,7 @@ export function LanguageProvider({ children }) {
   const [t, setT] = useState(translations.zh)
 
   useEffect(() => {
-    fetch('/api/locale')
+    fetch(API_PATHS.locale)
       .then((res) => res.json())
       .then((data) => {
         if (translations[data.lang]) {

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 import { useUserStore } from './store/userStore.js'
 
 function Login() {
@@ -16,7 +17,7 @@ function Login() {
     e.preventDefault()
     setMessage('')
     try {
-      const resp = await fetch('/api/users/login', {
+      const resp = await fetch(API_PATHS.login, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/glancy-site/src/Notifications.jsx
+++ b/glancy-site/src/Notifications.jsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Notifications() {
   const { t } = useLanguage()
   const [items, setItems] = useState([])
 
   const fetchData = () => {
-    fetch('/api/notifications')
+    fetch(API_PATHS.notifications)
       .then((res) => res.json())
       .then((data) => setItems(data))
       .catch(() => {})
@@ -18,7 +19,7 @@ function Notifications() {
   }, [])
 
   const markRead = async (id) => {
-    await fetch(`/api/notifications/${id}`, { method: 'POST' })
+    await fetch(`${API_PATHS.notifications}/${id}`, { method: 'POST' })
     fetchData()
   }
 

--- a/glancy-site/src/Portal.jsx
+++ b/glancy-site/src/Portal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Portal() {
   const { t } = useLanguage()
@@ -14,28 +15,28 @@ function Portal() {
   const [error, setError] = useState('')
 
   const loadStats = () => {
-    fetch('/api/stats/users')
+    fetch(API_PATHS.stats)
       .then((res) => res.json())
       .then((data) => setStats(data))
       .catch(() => {})
   }
 
   const loadConfig = () => {
-    fetch('/api/config')
+    fetch(API_PATHS.config)
       .then((res) => res.json())
       .then((data) => setConfig(Object.entries(data)))
       .catch(() => {})
   }
 
   const loadLogLevel = () => {
-    fetch('/api/log-level')
+    fetch(API_PATHS.logLevel)
       .then((res) => res.json())
       .then((data) => setLogLevel(data.level || 'info'))
       .catch(() => {})
   }
 
   const loadRecipients = () => {
-    fetch('/api/alerts/recipients')
+    fetch(API_PATHS.alertsRecipients)
       .then((res) => res.json())
       .then((data) => setRecipients(data))
       .catch(() => {})
@@ -45,7 +46,7 @@ function Portal() {
     e.preventDefault()
     setError('')
     try {
-      const resp = await fetch('/api/config', {
+      const resp = await fetch(API_PATHS.config, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ key: configKey, value: configValue })
@@ -66,7 +67,7 @@ function Portal() {
   const updateLogLevel = async () => {
     setError('')
     try {
-      const resp = await fetch('/api/log-level', {
+      const resp = await fetch(API_PATHS.logLevel, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ level: logLevel })
@@ -86,7 +87,7 @@ function Portal() {
     e.preventDefault()
     setError('')
     try {
-      const resp = await fetch('/api/alerts/recipients', {
+      const resp = await fetch(API_PATHS.alertsRecipients, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: newRecipient })
@@ -106,7 +107,7 @@ function Portal() {
   const deleteRecipient = async (email) => {
     setError('')
     try {
-      const resp = await fetch(`/api/alerts/recipients/${encodeURIComponent(email)}`, {
+      const resp = await fetch(`${API_PATHS.alertsRecipients}/${encodeURIComponent(email)}`, {
         method: 'DELETE'
       })
       if (!resp.ok) {

--- a/glancy-site/src/Preferences.jsx
+++ b/glancy-site/src/Preferences.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { useTheme } from './ThemeContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Preferences() {
   const { t } = useLanguage()
@@ -10,7 +11,7 @@ function Preferences() {
   const [message, setMessage] = useState('')
 
   useEffect(() => {
-    fetch('/api/preferences')
+    fetch(API_PATHS.preferences)
       .then((res) => res.json())
       .then((data) => {
         setLanguage(data.language || 'en')
@@ -21,7 +22,7 @@ function Preferences() {
 
   const handleSave = async (e) => {
     e.preventDefault()
-    await fetch('/api/preferences', {
+    await fetch(API_PATHS.preferences, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ language, theme })

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Profile() {
   const { t } = useLanguage()
@@ -9,7 +10,7 @@ function Profile() {
   const [message, setMessage] = useState('')
 
   useEffect(() => {
-    fetch('/api/users/profile')
+    fetch(API_PATHS.profile)
       .then((res) => res.json())
       .then((data) => {
         setUsername(data.username)
@@ -25,7 +26,7 @@ function Profile() {
     if (avatar) {
       formData.append('avatar', avatar)
     }
-    const resp = await fetch('/api/users/profile', {
+    const resp = await fetch(API_PATHS.profile, {
       method: 'POST',
       body: formData
     })
@@ -33,7 +34,7 @@ function Profile() {
   }
 
   const handleBind = async () => {
-    const resp = await fetch('/api/bind/third-party')
+    const resp = await fetch(API_PATHS.bindThirdParty)
     setMessage(resp.ok ? t.bindSuccess : t.submitFail)
   }
 

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Register() {
   const { t } = useLanguage()
@@ -14,7 +15,7 @@ function Register() {
     e.preventDefault()
     setMessage('')
     try {
-      const resp = await fetch('/api/users/register', {
+      const resp = await fetch(API_PATHS.register, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/glancy-site/src/UserDetail.jsx
+++ b/glancy-site/src/UserDetail.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function UserDetail() {
   const { t } = useLanguage()
@@ -10,7 +11,7 @@ function UserDetail() {
   const [message, setMessage] = useState('')
 
   useEffect(() => {
-    fetch(`/api/users/${id}`)
+    fetch(`${API_PATHS.users}/${id}`)
       .then((res) => res.json())
       .then((data) => {
         setUsername(data.username)
@@ -20,7 +21,7 @@ function UserDetail() {
 
   const handleUpdate = async (e) => {
     e.preventDefault()
-    const resp = await fetch(`/api/users/${id}`, {
+    const resp = await fetch(`${API_PATHS.users}/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username })

--- a/glancy-site/src/Users.jsx
+++ b/glancy-site/src/Users.jsx
@@ -2,13 +2,14 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
+import { API_PATHS } from './config/api.js'
 
 function Users() {
   const { t } = useLanguage()
   const [users, setUsers] = useState([])
 
   const fetchUsers = () => {
-    fetch('/api/users')
+    fetch(API_PATHS.users)
       .then((res) => res.json())
       .then((data) => setUsers(data))
       .catch(() => {})
@@ -19,7 +20,7 @@ function Users() {
   }, [])
 
   const handleDelete = async (id) => {
-    await fetch(`/api/users/${id}`, { method: 'DELETE' })
+    await fetch(`${API_PATHS.users}/${id}`, { method: 'DELETE' })
     fetchUsers()
   }
 

--- a/glancy-site/src/components/Header/UserProfile.jsx
+++ b/glancy-site/src/components/Header/UserProfile.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react'
 import './Header.css'
+import { API_PATHS } from '../../config/api.js'
 
 function UserProfile() {
   const [name, setName] = useState('')
 
   useEffect(() => {
-    fetch('/api/users/profile')
+    fetch(API_PATHS.profile)
       .then((res) => res.json())
       .then((data) => {
         if (data.username) {

--- a/glancy-site/src/config/api.js
+++ b/glancy-site/src/config/api.js
@@ -4,6 +4,8 @@ export const API_PATHS = {
   words: `${API_BASE}/words`,
   chat: `${API_BASE}/chat`,
   users: `${API_BASE}/users`,
+  login: `${API_BASE}/users/login`,
+  register: `${API_BASE}/users/register`,
   adminLogin: `${API_BASE}/admin/login`,
   stats: `${API_BASE}/stats/users`,
   config: `${API_BASE}/config`,
@@ -13,5 +15,8 @@ export const API_PATHS = {
   locale: `${API_BASE}/locale`,
   notifications: `${API_BASE}/notifications`,
   profile: `${API_BASE}/users/profile`,
-  preferences: `${API_BASE}/preferences`
+  preferences: `${API_BASE}/preferences`,
+  contact: `${API_BASE}/contact`,
+  bindThirdParty: `${API_BASE}/bind/third-party`,
+  faqs: `${API_BASE}/faqs`
 }


### PR DESCRIPTION
### Summary
- centralize API endpoints in `API_PATHS`
- replace hard-coded paths across components
- bump patch version
- add refactor notes

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6879e8f845488332934bb9230515fa0b