### PR TITLE
[fix] display user email

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.27",
+  "version": "0.0.28",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect } from 'react'
+import { useUserStore } from '../../store/userStore.js'
 import './Header.css'
 import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
@@ -8,7 +9,8 @@ import Avatar from '../Avatar.jsx'
 function UserMenu({ size = 24, showName = false }) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
-  const email = 'user@example.com'
+  const user = useUserStore((s) => s.user)
+  const email = user?.email || ''
   const isPro = true
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
- use user store email in `UserMenu`
- bump patch version

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a2f6edcf4833280079ebf25e78af1