### PR TITLE
[fix] hide sidebar info when logged out

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -2,9 +2,11 @@ import { useState, useEffect } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { fetchWord, fetchWordAudio } from './api/words.js'
+import { useUserStore } from './store/userStore.js'
 
 function Search() {
   const { t } = useLanguage()
+  const user = useUserStore((s) => s.user)
   const [word, setWord] = useState('')
   const [result, setResult] = useState(null)
   const [message, setMessage] = useState('')
@@ -54,7 +56,7 @@ function Search() {
           <button onClick={playAudio}>{t.playAudio}</button>
         </div>
       )}
-      {history.length > 0 && (
+      {user && history.length > 0 && (
         <div>
           <h3>{t.searchHistory}</h3>
           <button onClick={() => setHistory([])}>{t.clearHistory}</button>

--- a/glancy-site/src/components/Sidebar/SidebarFunctions.jsx
+++ b/glancy-site/src/components/Sidebar/SidebarFunctions.jsx
@@ -1,12 +1,14 @@
 import Favorites from './Favorites.jsx'
 import HistoryList from './HistoryList.jsx'
+import { useUserStore } from '../../store/userStore.js'
 import './Sidebar.css'
 
 function SidebarFunctions() {
+  const user = useUserStore((s) => s.user)
   return (
     <div className="sidebar-functions">
-      <Favorites />
-      <HistoryList />
+      {user && <Favorites />}
+      {user && <HistoryList />}
     </div>
   )
 }


### PR DESCRIPTION
### Summary
- hide favorites and search history unless user is logged in
- bump patch version to 0.0.29

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a3334e0c08332b87859f68ac79e6b