### PR TITLE
[fix] adjust user menu for guests

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -13,7 +13,8 @@
   padding: 0;
   border-radius: 0;
 }
-.user-menu button.with-name {
+.user-menu button.with-name,
+.user-menu .with-name {
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,5 +1,7 @@
 import { useRef, useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/userStore.js'
+import { useLanguage } from '../../LanguageContext.jsx'
 import './Header.css'
 import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
@@ -10,8 +12,9 @@ function UserMenu({ size = 24, showName = false }) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
   const user = useUserStore((s) => s.user)
+  const { t } = useLanguage()
   const email = user?.email || ''
-  const isPro = true
+  const isPro = !!user
 
   useEffect(() => {
     function handleClick(e) {
@@ -27,29 +30,42 @@ function UserMenu({ size = 24, showName = false }) {
 
   return (
     <div className="header-section user-menu" ref={menuRef}>
-      <button onClick={() => setOpen(!open)} className={showName ? 'with-name' : ''}>
-        <Avatar width={size} height={size} />
-        {isPro && <ProTag />}
-        {showName && <span className="username">{email}</span>}
-      </button>
-      {open && (
-        <div className="menu">
-          <div className="menu-header">
-            <div className="avatar">
-              <Avatar width={32} height={32} />
-              {isPro && <ProTag small />}
+      {user ? (
+        <>
+          <button onClick={() => setOpen(!open)} className={showName ? 'with-name' : ''}>
+            <Avatar width={size} height={size} />
+            {isPro && <ProTag />}
+            {showName && <span className="username">{email}</span>}
+          </button>
+          {open && (
+            <div className="menu">
+              <div className="menu-header">
+                <div className="avatar">
+                  <Avatar width={32} height={32} />
+                  {isPro && <ProTag small />}
+                </div>
+                <div className="email">{email}</div>
+              </div>
+              <ul>
+                <li><span className="icon">👤</span>Profile</li>
+                <li><span className="icon">⚙️</span>Settings</li>
+                <li><span className="icon">⌨️</span>Shortcuts</li>
+              </ul>
+              <ul>
+                <li><span className="icon">❓</span>Help</li>
+                <li><span className="icon">🔑</span>Log in</li>
+              </ul>
             </div>
-            <div className="email">{email}</div>
-          </div>
-          <ul>
-            <li><span className="icon">👤</span>Profile</li>
-            <li><span className="icon">⚙️</span>Settings</li>
-            <li><span className="icon">⌨️</span>Shortcuts</li>
-          </ul>
-          <ul>
-            <li><span className="icon">❓</span>Help</li>
-            <li><span className="icon">🔑</span>Log in</li>
-          </ul>
+          )}
+        </>
+      ) : (
+        <div className={showName ? 'with-name' : ''}>
+          <Avatar width={size} height={size} />
+          {showName && (
+            <Link to="/login" className="username login-btn">
+              {t.navRegister}/{t.navLogin}
+            </Link>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
### Summary
- hide pro tag when not logged in
- show Register/Login link next to avatar for guests
- bump patch version

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a32ee82348332b6054e2fa91c3b94