### PR TITLE
[feature] refresh brand click

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -20,6 +20,7 @@
   top: 0;
   background: inherit;
   padding-bottom: 1rem;
+  cursor: pointer;
 }
 .sidebar-brand img {
   width: 32px;

--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -8,8 +8,12 @@ function Brand() {
   const icon = hour >= 6 && hour < 18 ? lightIcon : darkIcon
   const text = lang === 'zh' ? '格律词典' : 'Glancy'
 
+  const handleClick = () => {
+    window.location.reload()
+  }
+
   return (
-    <div className="sidebar-brand">
+    <div className="sidebar-brand" onClick={handleClick}>
       <img src={icon} alt="Glancy" />
       <span>{text}</span>
     </div>


### PR DESCRIPTION
### Summary
- reload page when clicking the sidebar brand
- show pointer cursor and bump patch version

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687a33b6e4c08332b6d6f9cf1d0b2091