### PR TITLE
[feature] add auth modal

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/AuthModal.css
+++ b/glancy-site/src/components/AuthModal.css
@@ -1,0 +1,39 @@
+.auth-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.auth-modal {
+  background: var(--app-bg);
+  color: var(--app-color);
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 400px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.auth-tabs {
+  display: flex;
+  margin-bottom: 1rem;
+}
+
+.auth-tabs button {
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: inherit;
+}
+
+.auth-tabs button.active {
+  border-color: #646cff;
+}

--- a/glancy-site/src/components/AuthModal.jsx
+++ b/glancy-site/src/components/AuthModal.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import './AuthModal.css'
+import { useLanguage } from '../LanguageContext.jsx'
+import Login from '../Login.jsx'
+import Register from '../Register.jsx'
+
+function AuthModal({ open, onClose }) {
+  const { t } = useLanguage()
+  const [tab, setTab] = useState('register')
+  if (!open) return null
+  return (
+    <div className="auth-modal-overlay" onClick={onClose}>
+      <div className="auth-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="auth-tabs">
+          <button
+            type="button"
+            onClick={() => setTab('register')}
+            className={tab === 'register' ? 'active' : ''}
+          >
+            {t.navRegister}
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab('login')}
+            className={tab === 'login' ? 'active' : ''}
+          >
+            {t.navLogin}
+          </button>
+        </div>
+        {tab === 'register' ? <Register /> : <Login />}
+      </div>
+    </div>
+  )
+}
+
+export default AuthModal

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -116,3 +116,13 @@
   display: flex;
   align-items: center;
 }
+
+.login-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,15 +1,16 @@
 import { useRef, useState, useEffect } from 'react'
-import { Link } from 'react-router-dom'
 import { useUserStore } from '../../store/userStore.js'
 import { useLanguage } from '../../LanguageContext.jsx'
 import './Header.css'
 import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
+import AuthModal from '../AuthModal.jsx'
 
 // size 控制触发按钮中头像的尺寸
 
 function UserMenu({ size = 24, showName = false }) {
   const [open, setOpen] = useState(false)
+  const [modalOpen, setModalOpen] = useState(false)
   const menuRef = useRef(null)
   const user = useUserStore((s) => s.user)
   const { t } = useLanguage()
@@ -62,9 +63,16 @@ function UserMenu({ size = 24, showName = false }) {
         <div className={showName ? 'with-name' : ''}>
           <Avatar width={size} height={size} />
           {showName && (
-            <Link to="/login" className="username login-btn">
-              {t.navRegister}/{t.navLogin}
-            </Link>
+            <>
+              <button
+                type="button"
+                onClick={() => setModalOpen(true)}
+                className="username login-btn"
+              >
+                {t.navRegister}/{t.navLogin}
+              </button>
+              <AuthModal open={modalOpen} onClose={() => setModalOpen(false)} />
+            </>
           )}
         </div>
       )}


### PR DESCRIPTION
### Summary
- introduce `AuthModal` with tabs for register/login
- trigger modal from user menu when not logged in
- style login button and modal
- bump patch version to 0.0.30

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687a359c331483329b37d35b07f160d5