### PR TITLE
[fix] show pro tag only for subscribers

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -14,7 +14,7 @@ function UserMenu({ size = 24, showName = false }) {
   const user = useUserStore((s) => s.user)
   const { t } = useLanguage()
   const email = user?.email || ''
-  const isPro = !!user
+  const isPro = user?.isPro
 
   useEffect(() => {
     function handleClick(e) {


### PR DESCRIPTION
### Summary
- check `user.isPro` before showing pro badge
- bump patch version to 0.0.30

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687a360c391483329194198122344b50