### PR TITLE
[fix] adjust auth modal tab alignment

### DIFF
--- a/glancy-site/src/components/AuthModal.css
+++ b/glancy-site/src/components/AuthModal.css
@@ -24,6 +24,7 @@
 
 .auth-tabs {
   display: flex;
+  width: 100%;
   margin-bottom: 1rem;
 }
 
@@ -35,6 +36,7 @@
   cursor: pointer;
   border-bottom: 2px solid transparent;
   color: inherit;
+  text-align: center;
 }
 
 .auth-tabs button.active {


### PR DESCRIPTION
### Summary
- fill the auth tabs container width
- center the text inside each tab

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a396191bc8332bfd275a867289ac6