### PR TITLE
[fix] update sidebar background color

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.31",
+  "version": "0.0.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -7,7 +7,7 @@
 .sidebar {
   width: 240px;
   height: var(--vh);
-  background: #f2f2f2;
+  background: #121212;
   color: #fff;
   padding: 20px;
   display: flex;

--- a/glancy-site/src/components/Layout.css
+++ b/glancy-site/src/components/Layout.css
@@ -12,7 +12,7 @@ body {
 
 .sidebar {
   width: 260px;
-  background-color: #f2f2f2;
+  background-color: #121212;
   color: #fff;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Summary
- set sidebar background to `#121212`
- bump patch version to `0.0.32`

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687a38dcf4bc8332ae3a9c469fa62001