### PR TITLE
[fix] remove redundant deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,3 +53,4 @@ jobs:
           key: ${{ secrets.DEPLOY_KEY }}
           source: "glancy-site/dist/*"
           target: ${{ secrets.DEPLOY_PATH }}
+          strip_components: 2


### PR DESCRIPTION
### Summary
- avoid nested `glancy-site` folder during deployment by stripping path components

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687a887586408332afb0639eb8f065b7