### PR TITLE
[fix] show clean error messages

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.35",
+  "version": "0.0.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/AdminLogin.jsx
+++ b/glancy-site/src/AdminLogin.jsx
@@ -4,6 +4,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { extractMessage } from './utils.js'
 
 function AdminLogin() {
   const { t } = useLanguage()
@@ -24,7 +25,7 @@ function AdminLogin() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        throw new Error(text || t.loginButton + '失败')
+        throw new Error(extractMessage(text) || t.loginButton + '失败')
       }
       await resp.json()
       setPopupMsg(t.loginButton + '成功')

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -5,6 +5,7 @@ import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import { useUserStore } from './store/userStore.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { extractMessage } from './utils.js'
 
 function Login() {
   const { t } = useLanguage()
@@ -26,7 +27,7 @@ function Login() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        throw new Error(text || t.loginButton + '失败')
+        throw new Error(extractMessage(text) || t.loginButton + '失败')
       }
       const data = await resp.json()
       setUser(data)

--- a/glancy-site/src/Portal.jsx
+++ b/glancy-site/src/Portal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
+import { extractMessage } from './utils.js'
 
 function Portal() {
   const { t } = useLanguage()
@@ -53,7 +54,7 @@ function Portal() {
     })
       if (!resp.ok) {
         const text = await resp.text()
-        setError(text || 'Request failed')
+        setError(extractMessage(text) || 'Request failed')
         return
       }
       setConfigKey('')
@@ -74,7 +75,7 @@ function Portal() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        setError(text || 'Request failed')
+        setError(extractMessage(text) || 'Request failed')
         return
       }
       loadLogLevel()
@@ -94,7 +95,7 @@ function Portal() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        setError(text || 'Request failed')
+        setError(extractMessage(text) || 'Request failed')
         return
       }
       setNewRecipient('')
@@ -112,7 +113,7 @@ function Portal() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        setError(text || 'Request failed')
+        setError(extractMessage(text) || 'Request failed')
         return
       }
       loadRecipients()

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -4,6 +4,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { extractMessage } from './utils.js'
 
 function Register() {
   const { t } = useLanguage()
@@ -32,7 +33,7 @@ function Register() {
       })
       if (!resp.ok) {
         const text = await resp.text()
-        throw new Error(text || t.registerButton + '失败')
+        throw new Error(extractMessage(text) || t.registerButton + '失败')
       }
       await resp.json()
       setPopupMsg(t.registerButton + '成功')

--- a/glancy-site/src/utils.js
+++ b/glancy-site/src/utils.js
@@ -1,0 +1,12 @@
+export function extractMessage(text) {
+  if (!text) return ''
+  try {
+    const data = JSON.parse(text)
+    if (data && typeof data === 'object') {
+      return data.message || text
+    }
+  } catch {
+    // not JSON, ignore
+  }
+  return text
+}


### PR DESCRIPTION
### Summary
- parse server error responses to display only message text
- bump patch version to 0.0.36

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a9be406f48332ae85b89af1d3134e