### PR TITLE
[fix] login persistence

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.37",
+  "version": "0.0.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/store/userStore.js
+++ b/glancy-site/src/store/userStore.js
@@ -1,7 +1,19 @@
 import { create } from 'zustand'
 
-export const useUserStore = create((set) => ({
-  user: null,
-  setUser: (user) => set({ user }),
-  clearUser: () => set({ user: null })
-}))
+const STORAGE_KEY = 'user'
+
+export const useUserStore = create((set) => {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  const initialUser = stored ? JSON.parse(stored) : null
+  return {
+    user: initialUser,
+    setUser: (user) => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(user))
+      set({ user })
+    },
+    clearUser: () => {
+      localStorage.removeItem(STORAGE_KEY)
+      set({ user: null })
+    }
+  }
+})


### PR DESCRIPTION
### Summary
- save user info to localStorage to keep login after refresh
- bump version to 0.0.38

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687d36bd8f1083329b75789caeab865f