### PR TITLE
[fix] restore sidebar and icons on home page

### DIFF
--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "glancy-site",
   "private": true,
-  "version": "0.0.39",
+  "version": "0.0.40",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/glancy-site/src/Home.jsx
+++ b/glancy-site/src/Home.jsx
@@ -1,15 +1,43 @@
 import './components/Layout.css'
+import Brand from './components/Brand.jsx'
+import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
+import SidebarUser from './components/Sidebar/SidebarUser.jsx'
+import { useTheme } from './ThemeContext.jsx'
+import sendLight from './assets/send-button-light.svg'
+import sendDark from './assets/send-button-dark.svg'
+import voiceLight from './assets/voice-button-light.svg'
+import voiceDark from './assets/voice-button-dark.svg'
 
 function Home() {
+  const { resolvedTheme } = useTheme()
+  const sendIcon = resolvedTheme === 'dark' ? sendDark : sendLight
+  const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
+
   return (
-    <>
-      <h1 style={{ fontSize: '24px', marginBottom: '20px' }}>Where should we begin?</h1>
-      <form className="input-box">
-        <input type="text" placeholder="Ask anything" />
-        <button type="button" className="icon-btn">🎤</button>
-        <button type="submit" className="icon-btn">📶</button>
-      </form>
-    </>
+    <div className="container">
+      <aside className="sidebar">
+        <Brand />
+        <SidebarFunctions />
+        <SidebarUser />
+      </aside>
+      <div className="right">
+        <header className="topbar"></header>
+        <main className="display" style={{ flexDirection: 'column' }}>
+          <h1 style={{ fontSize: '24px', marginBottom: '20px' }}>
+            Where should we begin?
+          </h1>
+          <form className="input-box">
+            <input type="text" placeholder="Ask anything" />
+            <button type="button" className="icon-btn">
+              <img src={voiceIcon} alt="voice" />
+            </button>
+            <button type="submit" className="icon-btn">
+              <img src={sendIcon} alt="send" />
+            </button>
+          </form>
+        </main>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
### Summary
- show sidebar on home page
- use proper image icons in chatbox
- bump patch version to 0.0.40

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d3bb5419c8332811fe54361bc0875