### PR TITLE
[fix] import missing chat styles

### DIFF
--- a/glancy-site/src/Chat.jsx
+++ b/glancy-site/src/Chat.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import './App.css'
+import './Chat.css'
 import { sendChatMessage } from './api/chat.js'
 import { useTheme } from './ThemeContext.jsx'
 import sendLight from './assets/send-button-light.svg'


### PR DESCRIPTION
### Summary
- include Chat.css in Chat component to restore layout

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687d3e836a8c8332a1a6f2ec35175777