### PR TITLE
[fix] word search on homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ export default defineConfig({
 
 ## 词汇查询
 
-`/search` 调用 `/api/words?word=xxx` 获取单词释义，点击播放按钮则访问
+`/search` 调用 `/api/words?userId=1&term=hello&language=ENGLISH` 获取单词释义，
+实际请求需在头部加入 `X-USER-TOKEN`。点击播放按钮访问
 `/api/words/audio?word=xxx` 播放语音。
 
 ## 通知中心

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -7,7 +7,8 @@ import sendLight from './assets/send-button-light.svg'
 import sendDark from './assets/send-button-dark.svg'
 import voiceLight from './assets/voice-button-light.svg'
 import voiceDark from './assets/voice-button-dark.svg'
-import { sendChatMessage } from './api/chat.js'
+import { fetchWord } from './api/words.js'
+import { useLanguage } from './LanguageContext.jsx'
 import './App.css'
 import Brand from './components/Brand.jsx'
 import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
@@ -22,6 +23,7 @@ function App() {
   const [popupMsg, setPopupMsg] = useState('')
   const user = useUserStore((s) => s.user)
   const { resolvedTheme } = useTheme()
+  const { lang } = useLanguage()
   const sendIcon = resolvedTheme === 'dark' ? sendDark : sendLight
   const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
 
@@ -32,12 +34,17 @@ function App() {
       return
     }
     if (!text.trim()) return
-    const input = text
+    const input = text.trim()
     setText('')
     setLoading(true)
     try {
-      const data = await sendChatMessage(input)
-      setDisplay(data.reply)
+      const data = await fetchWord({
+        userId: user.id,
+        term: input,
+        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        token: user.token
+      })
+      setDisplay(data.definition)
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)

--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -6,7 +6,7 @@ import { useUserStore } from './store/userStore.js'
 import MessagePopup from './components/MessagePopup.jsx'
 
 function Search() {
-  const { t } = useLanguage()
+  const { t, lang } = useLanguage()
   const user = useUserStore((s) => s.user)
   const [word, setWord] = useState('')
   const [result, setResult] = useState(null)
@@ -25,7 +25,12 @@ function Search() {
     e.preventDefault()
     setPopupMsg('')
     try {
-      const data = await fetchWord(word)
+      const data = await fetchWord({
+        userId: user?.id,
+        term: word,
+        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        token: user?.token
+      })
       setResult(data)
       setHistory((h) => {
         const unique = Array.from(new Set([word, ...h]))

--- a/glancy-site/src/api/words.js
+++ b/glancy-site/src/api/words.js
@@ -1,7 +1,22 @@
 import { API_PATHS } from '../config/api.js'
 
-export async function fetchWord(word) {
-  const resp = await fetch(`${API_PATHS.words}?word=${encodeURIComponent(word)}`)
+/**
+ * Query a word definition
+ * @param {Object} opts
+ * @param {string|number} opts.userId current user id
+ * @param {string} opts.term word to search
+ * @param {string} opts.language CHINESE or ENGLISH
+ * @param {string} [opts.token] user token for auth header
+ */
+export async function fetchWord({ userId, term, language, token }) {
+  const params = new URLSearchParams({
+    userId,
+    term,
+    language
+  })
+  const resp = await fetch(`${API_PATHS.words}?${params.toString()}`, {
+    headers: token ? { 'X-USER-TOKEN': token } : {}
+  })
   if (!resp.ok) throw new Error('Failed to fetch')
   return resp.json()
 }


### PR DESCRIPTION
### Summary
- use `fetchWord` instead of chat API for homepage requests
- include user and language when querying `/api/words`

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687d4e2b6bb4833281cf2d67c6636f21