### PR TITLE
[fix] brand icon theme

### DIFF
--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -1,11 +1,12 @@
 import { useLanguage } from '../LanguageContext.jsx'
+import { useTheme } from '../ThemeContext.jsx'
 import lightIcon from '../assets/glancy-light.svg'
 import darkIcon from '../assets/glancy-dark.svg'
 
 function Brand() {
   const { lang } = useLanguage()
-  const hour = new Date().getHours()
-  const icon = hour >= 6 && hour < 18 ? lightIcon : darkIcon
+  const { resolvedTheme } = useTheme()
+  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
   const text = lang === 'zh' ? '格律词典' : 'Glancy'
 
   const handleClick = () => {


### PR DESCRIPTION
### Summary
- use `useTheme` in Brand component
- show light icon when theme is light

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687d64540d548332ac92c898f7024370