### PR TITLE
[fix] display missing word info

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -23,7 +23,7 @@ function App() {
   const [popupMsg, setPopupMsg] = useState('')
   const user = useUserStore((s) => s.user)
   const { resolvedTheme } = useTheme()
-  const { lang } = useLanguage()
+  const { lang, t } = useLanguage()
   const sendIcon = resolvedTheme === 'dark' ? sendDark : sendLight
   const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
 
@@ -44,7 +44,12 @@ function App() {
         language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
         token: user.token
       })
-      setDisplay(data.definition)
+      const text = data.definition ||
+        (data.definitions && data.definitions.length > 0
+          ? data.definitions.join('; ')
+          : '')
+      const output = [data.term, text].filter(Boolean).join(' ')
+      setDisplay(output || t.noDefinition)
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)

--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -64,7 +64,16 @@ function Search() {
       </form>
       {result && (
         <div>
-          <p>{result.definition}</p>
+          <h3>{result.term}</h3>
+          {result.definitions && result.definitions.length > 0 ? (
+            <ul>
+              {result.definitions.map((d, i) => (
+                <li key={i}>{d}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>{t.noDefinition}</p>
+          )}
           <button onClick={playAudio}>{t.playAudio}</button>
         </div>
       )}

--- a/glancy-site/src/translations.js
+++ b/glancy-site/src/translations.js
@@ -39,6 +39,7 @@ export const translations = {
     playAudio: '播放语音',
     favorites: '收藏夹',
     searchHistory: '搜索记录',
+    noDefinition: '暂无释义',
     clearHistory: '清空记录',
     notifications: '通知',
     markRead: '标为已读',
@@ -103,6 +104,7 @@ export const translations = {
     playAudio: 'Play',
     favorites: 'Favorites',
     searchHistory: 'History',
+    noDefinition: 'No definition',
     clearHistory: 'Clear History',
     notifications: 'Notifications',
     markRead: 'Mark read',
@@ -151,6 +153,7 @@ export const translations = {
     adminLoginTitle: 'Admin-Login',
     adminPortal: 'Admin-Bereich',
     adminWelcome: 'Willkommen im Administrationsbereich.',
+    noDefinition: 'Keine Definition',
     clearHistory: 'Verlauf löschen'
   },
   fr: {
@@ -177,6 +180,7 @@ export const translations = {
     adminLoginTitle: 'Connexion admin',
     adminPortal: 'Portail admin',
     adminWelcome: 'Bienvenue sur la page d\'administration.',
+    noDefinition: 'Pas de définition',
     clearHistory: 'Effacer l\'historique'
   },
   ru: {
@@ -203,6 +207,7 @@ export const translations = {
     adminLoginTitle: 'Вход администратора',
     adminPortal: 'Админ-портал',
     adminWelcome: 'Добро пожаловать в административный раздел.',
+    noDefinition: 'Нет определения',
     clearHistory: 'Очистить историю'
   },
   ja: {
@@ -229,6 +234,7 @@ export const translations = {
     adminLoginTitle: '管理者ログイン',
     adminPortal: '管理ポータル',
     adminWelcome: '管理ページへようこそ。',
+    noDefinition: '定義がありません',
     clearHistory: '履歴をクリア'
   },
   es: {
@@ -255,6 +261,7 @@ export const translations = {
     adminLoginTitle: 'Acceso de administrador',
     adminPortal: 'Portal de administración',
     adminWelcome: 'Bienvenido a la página de administración.',
+    noDefinition: 'Sin definición',
     clearHistory: 'Borrar historial'
   }
 }


### PR DESCRIPTION
### Summary
- show word term and definitions if present
- add `noDefinition` text for all languages

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d7026760883328781900e3c71d480