### PR TITLE
[feature] show complete word info

### DIFF
--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -63,16 +63,35 @@ function Search() {
         />
       </form>
       {result && (
-        <div>
+        <div className="result">
           <h3>{result.term}</h3>
+          {result.phonetic && (
+            <p>
+              <strong>{t.phonetic}:</strong> {result.phonetic}
+            </p>
+          )}
+          {result.language && (
+            <p>
+              <strong>{t.languageLabel}:</strong> {result.language}
+            </p>
+          )}
           {result.definitions && result.definitions.length > 0 ? (
-            <ul>
-              {result.definitions.map((d, i) => (
-                <li key={i}>{d}</li>
-              ))}
-            </ul>
+            <div>
+              <h4>{t.definitions}</h4>
+              <ul>
+                {result.definitions.map((d, i) => (
+                  <li key={i}>{d}</li>
+                ))}
+              </ul>
+            </div>
           ) : (
             <p>{t.noDefinition}</p>
+          )}
+          {result.example && (
+            <div>
+              <h4>{t.example}</h4>
+              <p>{result.example}</p>
+            </div>
           )}
           <button onClick={playAudio}>{t.playAudio}</button>
         </div>

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -155,3 +155,13 @@ button:focus-visible {
 :root[data-theme='light'] button {
   background-color: transparent;
 }
+
+.result {
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+}
+.result h4 {
+  margin: 0.5rem 0;
+}

--- a/glancy-site/src/translations.js
+++ b/glancy-site/src/translations.js
@@ -37,6 +37,10 @@ export const translations = {
     searchTitle: '词汇查询',
     searchButton: '搜索',
     playAudio: '播放语音',
+    phonetic: '音标',
+    example: '例句',
+    languageLabel: '语言',
+    definitions: '释义',
     favorites: '收藏夹',
     searchHistory: '搜索记录',
     noDefinition: '暂无释义',
@@ -102,6 +106,10 @@ export const translations = {
     searchTitle: 'Word Search',
     searchButton: 'Search',
     playAudio: 'Play',
+    phonetic: 'Phonetic',
+    example: 'Example',
+    languageLabel: 'Language',
+    definitions: 'Definitions',
     favorites: 'Favorites',
     searchHistory: 'History',
     noDefinition: 'No definition',
@@ -154,7 +162,11 @@ export const translations = {
     adminPortal: 'Admin-Bereich',
     adminWelcome: 'Willkommen im Administrationsbereich.',
     noDefinition: 'Keine Definition',
-    clearHistory: 'Verlauf löschen'
+    clearHistory: 'Verlauf löschen',
+    phonetic: 'Aussprache',
+    example: 'Beispiel',
+    languageLabel: 'Sprache',
+    definitions: 'Definitionen'
   },
   fr: {
     navHome: 'Accueil',
@@ -181,7 +193,11 @@ export const translations = {
     adminPortal: 'Portail admin',
     adminWelcome: 'Bienvenue sur la page d\'administration.',
     noDefinition: 'Pas de définition',
-    clearHistory: 'Effacer l\'historique'
+    clearHistory: 'Effacer l\'historique',
+    phonetic: 'Phonétique',
+    example: 'Exemple',
+    languageLabel: 'Langue',
+    definitions: 'Définitions'
   },
   ru: {
     navHome: 'Главная',
@@ -208,7 +224,11 @@ export const translations = {
     adminPortal: 'Админ-портал',
     adminWelcome: 'Добро пожаловать в административный раздел.',
     noDefinition: 'Нет определения',
-    clearHistory: 'Очистить историю'
+    clearHistory: 'Очистить историю',
+    phonetic: 'Фонетика',
+    example: 'Пример',
+    languageLabel: 'Язык',
+    definitions: 'Определения'
   },
   ja: {
     navHome: 'ホーム',
@@ -235,7 +255,11 @@ export const translations = {
     adminPortal: '管理ポータル',
     adminWelcome: '管理ページへようこそ。',
     noDefinition: '定義がありません',
-    clearHistory: '履歴をクリア'
+    clearHistory: '履歴をクリア',
+    phonetic: '発音',
+    example: '例文',
+    languageLabel: '言語',
+    definitions: '定義'
   },
   es: {
     navHome: 'Inicio',
@@ -262,6 +286,10 @@ export const translations = {
     adminPortal: 'Portal de administración',
     adminWelcome: 'Bienvenido a la página de administración.',
     noDefinition: 'Sin definición',
-    clearHistory: 'Borrar historial'
+    clearHistory: 'Borrar historial',
+    phonetic: 'Fonética',
+    example: 'Ejemplo',
+    languageLabel: 'Idioma',
+    definitions: 'Definiciones'
   }
 }


### PR DESCRIPTION
### Summary
- show phonetic, language, definitions and example on search results
- add translations for new labels
- style result section

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687d738929f88332996e95e18110768a