### PR TITLE
[feature] add settings modal

### DIFF
--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -5,12 +5,14 @@ import './Header.css'
 import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
 import AuthModal from '../AuthModal.jsx'
+import SettingsModal from '../SettingsModal.jsx'
 
 // size 控制触发按钮中头像的尺寸
 
 function UserMenu({ size = 24, showName = false }) {
   const [open, setOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
   const menuRef = useRef(null)
   const user = useUserStore((s) => s.user)
   const clearUser = useUserStore((s) => s.clearUser)
@@ -50,7 +52,9 @@ function UserMenu({ size = 24, showName = false }) {
               </div>
               <ul>
                 <li><span className="icon">👤</span>Profile</li>
-                <li><span className="icon">⚙️</span>Settings</li>
+                <li onClick={() => setSettingsOpen(true)}>
+                  <span className="icon">⚙️</span>Settings
+                </li>
                 <li><span className="icon">⌨️</span>Shortcuts</li>
               </ul>
               <ul>
@@ -89,6 +93,7 @@ function UserMenu({ size = 24, showName = false }) {
           )}
         </div>
       )}
+      <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </div>
   )
 }

--- a/glancy-site/src/components/SettingsModal.jsx
+++ b/glancy-site/src/components/SettingsModal.jsx
@@ -1,0 +1,15 @@
+import Preferences from '../Preferences.jsx'
+import './AuthModal.css'
+
+function SettingsModal({ open, onClose }) {
+  if (!open) return null
+  return (
+    <div className="auth-modal-overlay" onClick={onClose}>
+      <div className="auth-modal" onClick={(e) => e.stopPropagation()}>
+        <Preferences />
+      </div>
+    </div>
+  )
+}
+
+export default SettingsModal


### PR DESCRIPTION
### Summary
- implement SettingsModal component reusing AuthModal styles
- hook Settings modal into UserMenu so clicking Settings opens Preferences modal

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687dcd2c20648332888b294aee70d890