### PR TITLE
[fix] os detection for shortcuts

### DIFF
--- a/glancy-site/src/components/ShortcutsModal.jsx
+++ b/glancy-site/src/components/ShortcutsModal.jsx
@@ -1,13 +1,15 @@
 import './ShortcutsModal.css'
+import { getModifierKey } from '../utils.js'
 
 function ShortcutsModal({ open, onClose }) {
   if (!open) return null
 
+  const mod = getModifierKey()
   const shortcuts = [
-    { keys: 'Ctrl + /', action: 'Focus search input' },
-    { keys: 'Ctrl + L', action: 'Switch language' },
-    { keys: 'Ctrl + M', action: 'Toggle theme' },
-    { keys: 'Ctrl + K', action: 'Open shortcuts help' },
+    { keys: `${mod} + /`, action: 'Focus search input' },
+    { keys: `${mod} + L`, action: 'Switch language' },
+    { keys: `${mod} + M`, action: 'Toggle theme' },
+    { keys: `${mod} + K`, action: 'Open shortcuts help' },
   ]
 
   return (

--- a/glancy-site/src/utils.js
+++ b/glancy-site/src/utils.js
@@ -10,3 +10,9 @@ export function extractMessage(text) {
   }
   return text
 }
+
+export function getModifierKey() {
+  const platform =
+    navigator.userAgentData?.platform || navigator.platform || ''
+  return /Mac|iPhone|iPod|iPad/i.test(platform) ? 'Command \u2318' : 'Ctrl \u2303'
+}


### PR DESCRIPTION
### Summary
- show proper modifier key for keyboard shortcuts
- detect Mac or PC via browser info

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687dd1eb75ec8332a5400cee17dfab46