### PR TITLE
[feature] add dictionary entry component

### DIFF
--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -4,6 +4,7 @@ import { useLanguage } from './LanguageContext.jsx'
 import { fetchWord, fetchWordAudio } from './api/words.js'
 import { useUserStore } from './store/userStore.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import DictionaryEntry from './components/DictionaryEntry.jsx'
 
 function Search() {
   const { t, lang } = useLanguage()
@@ -64,35 +65,7 @@ function Search() {
       </form>
       {result && (
         <div className="result">
-          <h3>{result.term}</h3>
-          {result.phonetic && (
-            <p>
-              {t.phoneticLabel}: {result.phonetic}
-            </p>
-          )}
-          {result.language && (
-            <p>
-              {t.languageLabel}: {result.language}
-            </p>
-          )}
-          {result.definitions && result.definitions.length > 0 ? (
-            <section>
-              <h4>{t.definitionsLabel}</h4>
-              <ul>
-                {result.definitions.map((d, i) => (
-                  <li key={i}>{d}</li>
-                ))}
-              </ul>
-            </section>
-          ) : (
-            <p>{t.noDefinition}</p>
-          )}
-          {result.example && (
-            <section>
-              <h4>{t.exampleLabel}</h4>
-              <p>{result.example}</p>
-            </section>
-          )}
+          <DictionaryEntry entry={result} />
           <button onClick={playAudio}>{t.playAudio}</button>
         </div>
       )}

--- a/glancy-site/src/components/DictionaryEntry.css
+++ b/glancy-site/src/components/DictionaryEntry.css
@@ -1,0 +1,54 @@
+.dictionaryEntry {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+  border-bottom: 1px solid #eee;
+}
+
+.entryHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.term {
+  font-size: 1.6em;
+  font-weight: bold;
+  margin: 0;
+}
+
+.phonetic {
+  font-size: 0.9em;
+  color: #666;
+  margin-left: 8px;
+}
+
+.language {
+  display: inline-block;
+  background: #f5f5f5;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75em;
+  color: #333;
+}
+
+.definitions ol {
+  padding-left: 1.2em;
+}
+
+.definitions li {
+  margin-bottom: 0.6em;
+}
+
+.example blockquote {
+  margin: 0;
+  padding-left: 12px;
+  border-left: 3px solid #ddd;
+  font-style: italic;
+  color: #555;
+}
+
+.noDefinition {
+  color: #999;
+  margin: 12px 0;
+}

--- a/glancy-site/src/components/DictionaryEntry.jsx
+++ b/glancy-site/src/components/DictionaryEntry.jsx
@@ -1,0 +1,51 @@
+import { useLanguage } from '../LanguageContext.jsx'
+import './DictionaryEntry.css'
+
+function DictionaryEntry({ entry }) {
+  const { t } = useLanguage()
+  if (!entry) return null
+  const { term, phonetic, language, definitions, example } = entry
+
+  const languageMap = {
+    CHINESE: '中文',
+    ENGLISH: 'English'
+  }
+
+  const langLabel = languageMap[language] || language
+
+  return (
+    <article className="dictionaryEntry">
+      <header className="entryHeader">
+        <h1 className="term">
+          {term}
+          {phonetic && <span className="phonetic"> [{phonetic}]</span>}
+        </h1>
+        {language && <div className="language">{langLabel}</div>}
+      </header>
+      {definitions && definitions.length > 0 ? (
+        <section className="definitions" aria-labelledby="def-title">
+          <h2 id="def-title" className="sectionTitle">
+            {t.definitionsLabel}
+          </h2>
+          <ol>
+            {definitions.map((d, i) => (
+              <li key={i}>{d}</li>
+            ))}
+          </ol>
+        </section>
+      ) : (
+        <p className="noDefinition">{t.noDefinition}</p>
+      )}
+      {example && (
+        <section className="example" aria-labelledby="ex-title">
+          <h2 id="ex-title" className="sectionTitle">
+            {t.exampleLabel}
+          </h2>
+          <blockquote>{example}</blockquote>
+        </section>
+      )}
+    </article>
+  )
+}
+
+export default DictionaryEntry


### PR DESCRIPTION
### Summary
- add `DictionaryEntry` component for structured word details
- use new component in `Search` results

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dd31d49508332aa7101256ed89827