### PR TITLE
[fix] expand shortcuts modal width

### DIFF
--- a/glancy-site/src/components/ShortcutsModal.css
+++ b/glancy-site/src/components/ShortcutsModal.css
@@ -13,7 +13,7 @@
   color: var(--app-color);
   padding: 20px;
   border-radius: 8px;
-  width: 300px;
+  width: 400px;
   max-width: 90%;
 }
 


### PR DESCRIPTION
### Summary
- widen the Shortcuts modal so keyboard hints are easier to read

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dd53263748332bf75b4a07eb54d0a