### PR TITLE
[fix] keep popup open on hover

### DIFF
--- a/glancy-site/src/components/Layout.jsx
+++ b/glancy-site/src/components/Layout.jsx
@@ -51,7 +51,12 @@ function Layout() {
             </div>
           </div>
           <div className="plus-badge">PLUS</div>
-          {hover && <UserInfoCard />}
+          {hover && (
+            <UserInfoCard
+              onMouseEnter={() => setHover(true)}
+              onMouseLeave={() => setHover(false)}
+            />
+          )}
         </div>
         <Outlet />
       </main>

--- a/glancy-site/src/components/UserInfoCard.jsx
+++ b/glancy-site/src/components/UserInfoCard.jsx
@@ -1,8 +1,19 @@
 import './UserInfoCard.css'
 import Avatar from './Avatar.jsx'
 
-function UserInfoCard({ user = {} }) {
-  const { username = '', email = '', age = '', gender = '', interests = '', goal = '' } = user
+function UserInfoCard({
+  user = {},
+  onMouseEnter = () => {},
+  onMouseLeave = () => {},
+}) {
+  const {
+    username = '',
+    email = '',
+    age = '',
+    gender = '',
+    interests = '',
+    goal = '',
+  } = user
 
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -10,7 +21,11 @@ function UserInfoCard({ user = {} }) {
   }
 
   return (
-    <div className="user-card">
+    <div
+      className="user-card"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <div className="avatar-area">
         <Avatar width={80} height={80} style={{ borderRadius: '20px' }} />
       </div>


### PR DESCRIPTION
### Summary
- keep the user info card visible when hovering over it
- pass hover callbacks to the popup component

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ddbec90c083329cb4838fe968e95a