### PR TITLE
[fix] adjust mobile user menu

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -45,6 +45,9 @@
   align-items: center;
   padding: 0 20px;
 }
+.topbar .user-menu {
+  display: none;
+}
 
 .avatar img {
   width: 32px;
@@ -109,6 +112,12 @@
   }
   .right {
     height: auto;
+  }
+  .sidebar-user {
+    display: none;
+  }
+  .topbar .user-menu {
+    display: flex;
   }
   .chatbox {
     padding: 16px;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -13,6 +13,7 @@ import './App.css'
 import Brand from './components/Brand.jsx'
 import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
 import SidebarUser from './components/Sidebar/SidebarUser.jsx'
+import UserMenu from './components/Header/UserMenu.jsx'
 
 function App() {
   const [text, setText] = useState('')
@@ -71,7 +72,9 @@ function App() {
         <SidebarUser />
       </aside>
       <div className="right">
-        <header className="topbar"></header>
+        <header className="topbar">
+          <UserMenu size={32} />
+        </header>
         <main className="display">{loading ? '...' : display}</main>
         <form className="chatbox" onSubmit={handleSend}>
           <input

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -95,6 +95,13 @@
   padding-top: 0.5rem;
 }
 
+@media (max-width: 600px) {
+  .topbar .user-menu .menu {
+    top: calc(100% + 0.5rem);
+    bottom: auto;
+  }
+}
+
 .app-header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
### Summary
- move dropdown orientation to component CSS
- keep topbar menu hidden on desktop

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687ddad51bb88332813ea551f00af919