### PR TITLE
[fix] mobile brand user menu

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -16,11 +16,19 @@
 .sidebar-brand {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   position: sticky;
   top: 0;
   background: inherit;
   padding-bottom: 1rem;
   cursor: pointer;
+}
+.brand-main {
+  display: flex;
+  align-items: center;
+}
+.mobile-user-menu {
+  display: none;
 }
 .sidebar-brand img {
   width: 32px;
@@ -44,9 +52,6 @@
   justify-content: flex-end;
   align-items: center;
   padding: 0 20px;
-}
-.topbar .user-menu {
-  display: none;
 }
 
 .avatar img {
@@ -116,8 +121,11 @@
   .sidebar-user {
     display: none;
   }
-  .topbar .user-menu {
-    display: flex;
+  .mobile-user-menu {
+    display: block;
+  }
+  .topbar {
+    display: none;
   }
   .chatbox {
     padding: 16px;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -14,7 +14,6 @@ import './App.css'
 import Brand from './components/Brand.jsx'
 import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
 import SidebarUser from './components/Sidebar/SidebarUser.jsx'
-import UserMenu from './components/Header/UserMenu.jsx'
 
 function App() {
   const [text, setText] = useState('')
@@ -112,9 +111,7 @@ function App() {
         <SidebarUser />
       </aside>
       <div className="right">
-        <header className="topbar">
-          <UserMenu size={32} />
-        </header>
+        <header className="topbar"></header>
         <main className="display">{loading ? '...' : display}</main>
         <form className="chatbox" onSubmit={handleSend}>
           <input

--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -2,6 +2,7 @@ import { useLanguage } from '../LanguageContext.jsx'
 import { useTheme } from '../ThemeContext.jsx'
 import lightIcon from '../assets/glancy-light.svg'
 import darkIcon from '../assets/glancy-dark.svg'
+import UserMenu from './Header/UserMenu.jsx'
 
 function Brand() {
   const { lang } = useLanguage()
@@ -15,8 +16,13 @@ function Brand() {
 
   return (
     <div className="sidebar-brand" onClick={handleClick}>
-      <img src={icon} alt="Glancy" />
-      <span>{text}</span>
+      <div className="brand-main">
+        <img src={icon} alt="Glancy" />
+        <span>{text}</span>
+      </div>
+      <div className="mobile-user-menu">
+        <UserMenu size={28} />
+      </div>
     </div>
   )
 }

--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -96,7 +96,7 @@
 }
 
 @media (max-width: 600px) {
-  .topbar .user-menu .menu {
+  .mobile-user-menu .user-menu .menu {
     top: calc(100% + 0.5rem);
     bottom: auto;
   }

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -44,3 +44,9 @@
 background-color: rgba(255, 255, 255, 0.1);
 border-radius: 4px;
 }
+
+@media (max-width: 600px) {
+  .sidebar-user {
+    display: none;
+  }
+}


### PR DESCRIPTION
### Summary
- embed a compact UserMenu into the sidebar brand
- hide sidebar user section on small screens and hide the header
- adjust menu positioning for the mobile brand menu

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687ddea97fcc8332ac3a3082fa939d82