### PR TITLE
[fix] keep user menu open on mobile

### DIFF
--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -27,15 +27,15 @@ function UserMenu({ size = 24, showName = false }) {
   const isPro = user?.isPro
 
   useEffect(() => {
-    function handleClick(e) {
+    function handlePointerDown(e) {
       if (menuRef.current && !menuRef.current.contains(e.target)) {
         setOpen(false)
       }
     }
     if (open) {
-      document.addEventListener('click', handleClick)
+      document.addEventListener('pointerdown', handlePointerDown)
     }
-    return () => document.removeEventListener('click', handleClick)
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
   }, [open])
 
   useEffect(() => {


### PR DESCRIPTION
### Summary
- close mobile menu with `pointerdown` to prevent instant dismissal

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687de09bb50483329526858dff7d668d