### PR TITLE
[fix] restrict brand click area

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -21,11 +21,11 @@
   top: 0;
   background: inherit;
   padding-bottom: 1rem;
-  cursor: pointer;
 }
 .brand-main {
   display: flex;
   align-items: center;
+  cursor: pointer;
 }
 .mobile-user-menu {
   display: none;

--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -15,8 +15,8 @@ function Brand() {
   }
 
   return (
-    <div className="sidebar-brand" onClick={handleClick}>
-      <div className="brand-main">
+    <div className="sidebar-brand">
+      <div className="brand-main" onClick={handleClick}>
         <img src={icon} alt="Glancy" />
         <span>{text}</span>
       </div>


### PR DESCRIPTION
### Summary
- move refresh click handler to `.brand-main`
- update styles so only brand icon and text show pointer cursor

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687de2c2a6e88332b995a01b6505d4ef