### PR TITLE
[refactor] add api client

### DIFF
--- a/glancy-site/src/AdminLogin.jsx
+++ b/glancy-site/src/AdminLogin.jsx
@@ -4,7 +4,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
-import { extractMessage } from './utils.js'
+import { apiRequest } from './api/client.js'
 
 function AdminLogin() {
   const { t } = useLanguage()
@@ -18,16 +18,11 @@ function AdminLogin() {
     e.preventDefault()
     setPopupMsg('')
     try {
-      const resp = await fetch(API_PATHS.adminLogin, {
+      await apiRequest(API_PATHS.adminLogin, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })
       })
-      if (!resp.ok) {
-        const text = await resp.text()
-        throw new Error(extractMessage(text) || t.loginButton + '失败')
-      }
-      await resp.json()
       setPopupMsg(t.loginButton + '成功')
       setPopupOpen(true)
       navigate('/portal')

--- a/glancy-site/src/Contact.jsx
+++ b/glancy-site/src/Contact.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
+import { apiRequest } from './api/client.js'
 
 function Contact() {
   const { t } = useLanguage()
@@ -12,12 +13,12 @@ function Contact() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    const resp = await fetch(API_PATHS.contact, {
+    await apiRequest(API_PATHS.contact, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, email, message: msg })
     })
-    setInfo(resp.ok ? t.submitSuccess : t.submitFail)
+    setInfo(t.submitSuccess)
   }
 
   return (

--- a/glancy-site/src/Faq.jsx
+++ b/glancy-site/src/Faq.jsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
+import { apiRequest } from './api/client.js'
 
 function Faq() {
   const { t } = useLanguage()
   const [items, setItems] = useState([])
 
   useEffect(() => {
-    fetch(API_PATHS.faqs)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.faqs)
       .then((data) => setItems(data))
       .catch(() => {})
   }, [])

--- a/glancy-site/src/Health.jsx
+++ b/glancy-site/src/Health.jsx
@@ -2,14 +2,15 @@ import { useState, useEffect, useCallback } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
+import { apiRequest } from './api/client.js'
 
 function Health() {
   const { t } = useLanguage()
   const [status, setStatus] = useState('')
 
   const check = useCallback(() => {
-    fetch(API_PATHS.ping)
-      .then((res) => setStatus(res.ok ? t.ok : t.fail))
+    apiRequest(API_PATHS.ping)
+      .then(() => setStatus(t.ok))
       .catch(() => setStatus(t.fail))
   }, [t])
 

--- a/glancy-site/src/LanguageContext.jsx
+++ b/glancy-site/src/LanguageContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { translations } from './translations.js'
 import { API_PATHS } from './config/api.js'
+import { apiRequest } from './api/client.js'
 
 const LanguageContext = createContext({
   lang: 'zh',
@@ -13,8 +14,7 @@ export function LanguageProvider({ children }) {
   const [t, setT] = useState(translations.zh)
 
   useEffect(() => {
-    fetch(API_PATHS.locale)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.locale)
       .then((data) => {
         if (translations[data.lang]) {
           setLang(data.lang)

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -5,7 +5,7 @@ import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import { useUserStore } from './store/userStore.js'
 import MessagePopup from './components/MessagePopup.jsx'
-import { extractMessage } from './utils.js'
+import { apiRequest } from './api/client.js'
 
 function Login() {
   const { t } = useLanguage()
@@ -20,16 +20,11 @@ function Login() {
     e.preventDefault()
     setPopupMsg('')
     try {
-      const resp = await fetch(API_PATHS.login, {
+      const data = await apiRequest(API_PATHS.login, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ account, password })
       })
-      if (!resp.ok) {
-        const text = await resp.text()
-        throw new Error(extractMessage(text) || t.loginButton + '失败')
-      }
-      const data = await resp.json()
       setUser(data)
       setPopupMsg(`${t.loginButton} ${account}`)
       setPopupOpen(true)

--- a/glancy-site/src/Notifications.jsx
+++ b/glancy-site/src/Notifications.jsx
@@ -3,6 +3,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { apiRequest } from './api/client.js'
 
 function Notifications() {
   const { t } = useLanguage()
@@ -11,8 +12,7 @@ function Notifications() {
   const [popupMsg, setPopupMsg] = useState('')
 
   const fetchData = () => {
-    fetch(API_PATHS.notifications)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.notifications)
       .then((data) => setItems(data))
       .catch(() => {
         setPopupMsg('Failed to fetch notifications')
@@ -25,7 +25,7 @@ function Notifications() {
   }, [])
 
   const markRead = async (id) => {
-    await fetch(`${API_PATHS.notifications}/${id}`, { method: 'POST' })
+    await apiRequest(`${API_PATHS.notifications}/${id}`, { method: 'POST' })
     fetchData()
   }
 

--- a/glancy-site/src/Portal.jsx
+++ b/glancy-site/src/Portal.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
-import { extractMessage } from './utils.js'
+import { apiRequest } from './api/client.js'
 
 function Portal() {
   const { t } = useLanguage()
@@ -16,29 +16,25 @@ function Portal() {
   const [error, setError] = useState('')
 
   const loadStats = () => {
-    fetch(API_PATHS.stats)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.stats)
       .then((data) => setStats(data))
       .catch(() => {})
   }
 
   const loadConfig = () => {
-    fetch(API_PATHS.config)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.config)
       .then((data) => setConfig(Object.entries(data)))
       .catch(() => {})
   }
 
   const loadLogLevel = () => {
-    fetch(API_PATHS.logLevel)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.logLevel)
       .then((data) => setLogLevel(data.level || 'info'))
       .catch(() => {})
   }
 
   const loadRecipients = () => {
-    fetch(API_PATHS.alertsRecipients)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.alertsRecipients)
       .then((data) => setRecipients(data))
       .catch(() => {})
   }
@@ -47,16 +43,11 @@ function Portal() {
     e.preventDefault()
     setError('')
     try {
-      const resp = await fetch(API_PATHS.config, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ key: configKey, value: configValue })
-    })
-      if (!resp.ok) {
-        const text = await resp.text()
-        setError(extractMessage(text) || 'Request failed')
-        return
-      }
+      await apiRequest(API_PATHS.config, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: configKey, value: configValue })
+      })
       setConfigKey('')
       setConfigValue('')
       loadConfig()
@@ -68,16 +59,11 @@ function Portal() {
   const updateLogLevel = async () => {
     setError('')
     try {
-      const resp = await fetch(API_PATHS.logLevel, {
+      await apiRequest(API_PATHS.logLevel, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ level: logLevel })
       })
-      if (!resp.ok) {
-        const text = await resp.text()
-        setError(extractMessage(text) || 'Request failed')
-        return
-      }
       loadLogLevel()
     } catch (err) {
       setError(err.message)
@@ -88,16 +74,11 @@ function Portal() {
     e.preventDefault()
     setError('')
     try {
-      const resp = await fetch(API_PATHS.alertsRecipients, {
+      await apiRequest(API_PATHS.alertsRecipients, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: newRecipient })
       })
-      if (!resp.ok) {
-        const text = await resp.text()
-        setError(extractMessage(text) || 'Request failed')
-        return
-      }
       setNewRecipient('')
       loadRecipients()
     } catch (err) {
@@ -108,14 +89,9 @@ function Portal() {
   const deleteRecipient = async (email) => {
     setError('')
     try {
-      const resp = await fetch(`${API_PATHS.alertsRecipients}/${encodeURIComponent(email)}`, {
+      await apiRequest(`${API_PATHS.alertsRecipients}/${encodeURIComponent(email)}`, {
         method: 'DELETE'
       })
-      if (!resp.ok) {
-        const text = await resp.text()
-        setError(extractMessage(text) || 'Request failed')
-        return
-      }
       loadRecipients()
     } catch (err) {
       setError(err.message)

--- a/glancy-site/src/Preferences.jsx
+++ b/glancy-site/src/Preferences.jsx
@@ -5,6 +5,7 @@ import { useTheme } from './ThemeContext.jsx'
 import { useUserStore } from './store/userStore.js'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { apiRequest } from './api/client.js'
 
 function Preferences() {
   const { t } = useLanguage()
@@ -18,8 +19,7 @@ function Preferences() {
 
   useEffect(() => {
     if (!user) return
-    fetch(`${API_PATHS.preferences}/user/${user.id}`)
-      .then((res) => res.json())
+    apiRequest(`${API_PATHS.preferences}/user/${user.id}`)
       .then((data) => {
         setSystemLanguage(data.systemLanguage || 'en')
         setSearchLanguage(data.searchLanguage || 'ENGLISH')
@@ -32,7 +32,7 @@ function Preferences() {
   const handleSave = async (e) => {
     e.preventDefault()
     if (!user) return
-    await fetch(`${API_PATHS.preferences}/user/${user.id}`, {
+    await apiRequest(`${API_PATHS.preferences}/user/${user.id}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -3,6 +3,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { apiRequest } from './api/client.js'
 
 function Profile() {
   const { t } = useLanguage()
@@ -12,8 +13,7 @@ function Profile() {
   const [popupMsg, setPopupMsg] = useState('')
 
   useEffect(() => {
-    fetch(API_PATHS.profile)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.profile)
       .then((data) => {
         setUsername(data.username)
         setAvatar(data.avatar)
@@ -28,17 +28,17 @@ function Profile() {
     if (avatar) {
       formData.append('avatar', avatar)
     }
-    const resp = await fetch(API_PATHS.profile, {
+    await apiRequest(API_PATHS.profile, {
       method: 'POST',
       body: formData
     })
-    setPopupMsg(resp.ok ? t.updateSuccess : t.submitFail)
+    setPopupMsg(t.updateSuccess)
     setPopupOpen(true)
   }
 
   const handleBind = async () => {
-    const resp = await fetch(API_PATHS.bindThirdParty)
-    setPopupMsg(resp.ok ? t.bindSuccess : t.submitFail)
+    await apiRequest(API_PATHS.bindThirdParty)
+    setPopupMsg(t.bindSuccess)
     setPopupOpen(true)
   }
 

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -4,7 +4,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
-import { extractMessage } from './utils.js'
+import { apiRequest } from './api/client.js'
 
 function Register() {
   const { t } = useLanguage()
@@ -26,16 +26,11 @@ function Register() {
       return
     }
     try {
-      const resp = await fetch(API_PATHS.register, {
+      await apiRequest(API_PATHS.register, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, phone, password })
       })
-      if (!resp.ok) {
-        const text = await resp.text()
-        throw new Error(extractMessage(text) || t.registerButton + '失败')
-      }
-      await resp.json()
       setPopupMsg(t.registerButton + '成功')
       setPopupOpen(true)
       navigate('/login')

--- a/glancy-site/src/UserDetail.jsx
+++ b/glancy-site/src/UserDetail.jsx
@@ -4,6 +4,7 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
+import { apiRequest } from './api/client.js'
 
 function UserDetail() {
   const { t } = useLanguage()
@@ -13,8 +14,7 @@ function UserDetail() {
   const [popupMsg, setPopupMsg] = useState('')
 
   useEffect(() => {
-    fetch(`${API_PATHS.users}/${id}`)
-      .then((res) => res.json())
+    apiRequest(`${API_PATHS.users}/${id}`)
       .then((data) => {
         setUsername(data.username)
       })
@@ -23,12 +23,12 @@ function UserDetail() {
 
   const handleUpdate = async (e) => {
     e.preventDefault()
-    const resp = await fetch(`${API_PATHS.users}/${id}`, {
+    await apiRequest(`${API_PATHS.users}/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username })
     })
-    setPopupMsg(resp.ok ? t.updateSuccess : t.submitFail)
+    setPopupMsg(t.updateSuccess)
     setPopupOpen(true)
   }
 

--- a/glancy-site/src/Users.jsx
+++ b/glancy-site/src/Users.jsx
@@ -3,14 +3,14 @@ import { Link } from 'react-router-dom'
 import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
+import { apiRequest } from './api/client.js'
 
 function Users() {
   const { t } = useLanguage()
   const [users, setUsers] = useState([])
 
   const fetchUsers = () => {
-    fetch(API_PATHS.users)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.users)
       .then((data) => setUsers(data))
       .catch(() => {})
   }
@@ -20,7 +20,7 @@ function Users() {
   }, [])
 
   const handleDelete = async (id) => {
-    await fetch(`${API_PATHS.users}/${id}`, { method: 'DELETE' })
+    await apiRequest(`${API_PATHS.users}/${id}`, { method: 'DELETE' })
     fetchUsers()
   }
 

--- a/glancy-site/src/api/chat.js
+++ b/glancy-site/src/api/chat.js
@@ -1,11 +1,9 @@
 import { API_PATHS } from '../config/api.js'
+import { apiRequest } from './client.js'
 
-export async function sendChatMessage(text) {
-  const resp = await fetch(API_PATHS.chat, {
+export const sendChatMessage = (text) =>
+  apiRequest(API_PATHS.chat, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ text })
   })
-  if (!resp.ok) throw new Error('Failed to fetch')
-  return resp.json()
-}

--- a/glancy-site/src/api/client.js
+++ b/glancy-site/src/api/client.js
@@ -1,0 +1,14 @@
+import { extractMessage } from '../utils.js'
+
+export async function apiRequest(url, options = {}) {
+  const resp = await fetch(url, options)
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '')
+    throw new Error(extractMessage(text) || 'Request failed')
+  }
+  const contentType = resp.headers.get('content-type') || ''
+  if (contentType.includes('application/json')) {
+    return resp.json()
+  }
+  return resp
+}

--- a/glancy-site/src/api/words.js
+++ b/glancy-site/src/api/words.js
@@ -1,4 +1,5 @@
 import { API_PATHS } from '../config/api.js'
+import { apiRequest } from './client.js'
 
 /**
  * Query a word definition
@@ -14,11 +15,9 @@ export async function fetchWord({ userId, term, language, token }) {
     term,
     language
   })
-  const resp = await fetch(`${API_PATHS.words}?${params.toString()}`, {
+  return apiRequest(`${API_PATHS.words}?${params.toString()}`, {
     headers: token ? { 'X-USER-TOKEN': token } : {}
   })
-  if (!resp.ok) throw new Error('Failed to fetch')
-  return resp.json()
 }
 
 export async function fetchWordAudio(word) {

--- a/glancy-site/src/components/Header/UserProfile.jsx
+++ b/glancy-site/src/components/Header/UserProfile.jsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react'
 import './Header.css'
 import { API_PATHS } from '../../config/api.js'
+import { apiRequest } from '../../api/client.js'
 
 function UserProfile() {
   const [name, setName] = useState('')
 
   useEffect(() => {
-    fetch(API_PATHS.profile)
-      .then((res) => res.json())
+    apiRequest(API_PATHS.profile)
       .then((data) => {
         if (data.username) {
           setName(data.username)


### PR DESCRIPTION
### Summary
- centralize HTTP fetch logic with new `apiRequest` helper
- update components to use the new client

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687de5664fc08332865f380536220575