### PR TITLE
[fix] remove login success popup

### DIFF
--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -26,9 +26,7 @@ function Login() {
         body: JSON.stringify({ account, password })
       })
       setUser(data)
-      setPopupMsg(`${t.loginButton} ${account}`)
-      setPopupOpen(true)
-      navigate('/')
+      navigate(0)
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)


### PR DESCRIPTION
### Summary
- skip success popup when users log in

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687df00ddb748332bd85182de1c52be9