### PR TITLE
[fix] maintain scrollable results

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -41,9 +41,9 @@
 
 .right {
   flex: 1;
-  height: var(--vh);
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .topbar {
@@ -114,9 +114,6 @@
     width: 100%;
     height: auto;
     padding: 10px;
-  }
-  .right {
-    height: auto;
   }
   .sidebar-user {
     display: none;


### PR DESCRIPTION
### Summary
- keep results view scrollable with `min-height: 0`
- remove height override for `.right` on mobile

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687defbe2ab083328f6e8b36480fe459