### PR TITLE
[fix] enable plan selection

### DIFF
--- a/glancy-site/src/components/UpgradeModal.css
+++ b/glancy-site/src/components/UpgradeModal.css
@@ -36,7 +36,8 @@
 }
 
 .plan.selected {
-  background: var(--sidebar-bg);
+  border-color: var(--accent-color);
+  background: rgba(250, 204, 21, 0.2);
 }
 
 .actions {

--- a/glancy-site/src/components/UpgradeModal.jsx
+++ b/glancy-site/src/components/UpgradeModal.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useUserStore } from '../store/userStore.js'
 import PaymentModal from './PaymentModal.jsx'
 import './UpgradeModal.css'
@@ -8,6 +8,12 @@ function UpgradeModal({ open, onClose }) {
   const currentPlan = user?.plan || 'free'
   const [selected, setSelected] = useState(currentPlan)
   const [payOpen, setPayOpen] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setSelected(currentPlan)
+    }
+  }, [open, currentPlan])
 
   if (!open) return null
 
@@ -34,8 +40,8 @@ function UpgradeModal({ open, onClose }) {
           {plans.map((p) => (
             <div
               key={p.id}
-              className={`plan${p.id === currentPlan ? ' current' : ''}$
-                {selected === p.id ? ' selected' : ''}`}
+              className={`plan${p.id === currentPlan ? ' current' : ''}${
+                selected === p.id ? ' selected' : ''}`}
               onClick={() => setSelected(p.id)}
             >
               {p.label}


### PR DESCRIPTION
### Summary
- reset selected plan when the upgrade dialog opens
- highlight the chosen plan with accent color

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687df4a3f3148332a96a3fd6e0c14eda