### PR TITLE
[fix] improve search result layout

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -64,13 +64,23 @@
   flex: 1;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   padding: 20px;
   overflow-y: auto;
   overscroll-behavior: contain;
   font-size: 2rem;
   font-weight: bold;
   text-align: center;
+}
+
+.display-content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.display-term {
+  margin-bottom: 1rem;
 }
 
 

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -17,7 +17,7 @@ import SidebarUser from './components/Sidebar/SidebarUser.jsx'
 
 function App() {
   const [text, setText] = useState('')
-  const [display, setDisplay] = useState('What are we querying next?')
+  const [display, setDisplay] = useState(['What are we querying next?'])
   const [loading, setLoading] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [popupOpen, setPopupOpen] = useState(false)
@@ -51,12 +51,12 @@ function App() {
         (data.definitions && data.definitions.length > 0
           ? data.definitions.join('; ')
           : '')
-      const parts = [data.term]
-      if (data.phonetic) parts.push(`(${data.phonetic})`)
-      if (defs) parts.push(defs)
-      if (data.example) parts.push(`"${data.example}"`)
-      const output = parts.join(' ')
-      setDisplay(output || t.noDefinition)
+      const details = []
+      if (data.phonetic) details.push(`(${data.phonetic})`)
+      if (defs) details.push(defs)
+      if (data.example) details.push(`"${data.example}"`)
+      const output = details.join(' ')
+      setDisplay([data.term, output || t.noDefinition])
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)
@@ -112,7 +112,22 @@ function App() {
       </aside>
       <div className="right">
         <header className="topbar"></header>
-        <main className="display">{loading ? '...' : display}</main>
+        <main className="display">
+          {loading ? (
+            '...'
+          ) : (
+            <div className="display-content">
+              {display.map((line, idx) => (
+                <div
+                  key={idx}
+                  className={idx === 0 ? 'display-term' : undefined}
+                >
+                  {line}
+                </div>
+              ))}
+            </div>
+          )}
+        </main>
         <form className="chatbox" onSubmit={handleSend}>
           <input
             ref={inputRef}


### PR DESCRIPTION
### Summary
- Fix display area alignment to prevent top text from being hidden
- Show search term on its own centered line

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687df8c581548332b958e9b99f4d40d8