### PR TITLE
[fix] adjust plan highlight colors

### DIFF
--- a/glancy-site/src/components/UpgradeModal.css
+++ b/glancy-site/src/components/UpgradeModal.css
@@ -31,13 +31,16 @@
   cursor: pointer;
 }
 
+
 .plan.current {
-  border-color: var(--accent-color);
+  /* highlight current plan using system black */
+  border-color: #000;
 }
 
 .plan.selected {
-  border-color: var(--sidebar-bg);
-  background: color-mix(in srgb, var(--sidebar-bg), transparent 80%);
+  /* highlight selected plan with transparent system black */
+  border-color: #000;
+  background: color-mix(in srgb, #000, transparent 80%);
 }
 
 .actions {


### PR DESCRIPTION
### Summary
- tweak UpgradeModal styles so current and selected plans use system black borders
- apply a translucent black background to the selected plan

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687dfd6d2a188332931b89867598e3a7