### PR TITLE
[fix] update plan highlight colors

### DIFF
--- a/glancy-site/src/components/UpgradeModal.css
+++ b/glancy-site/src/components/UpgradeModal.css
@@ -32,15 +32,16 @@
 }
 
 
+
 .plan.current {
-  /* highlight current plan using system black */
-  border-color: #000;
+  /* highlight current plan using custom black */
+  border-color: #121212;
 }
 
 .plan.selected {
-  /* highlight selected plan with transparent system black */
-  border-color: #000;
-  background: color-mix(in srgb, #000, transparent 80%);
+  /* highlight selected plan with semi-transparent black */
+  border-color: #121212;
+  background: color-mix(in srgb, #121212, transparent 20%);
 }
 
 .actions {


### PR DESCRIPTION
### Summary
- tweak highlight colors for plan selection

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e073755a483329bbdec92582cef3c