### PR TITLE
[feature] prefill profile info

### DIFF
--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -6,11 +6,13 @@ import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
 import { apiRequest } from './api/client.js'
+import { useUserStore } from './store/userStore.js'
 
 function Profile({ onCancel }) {
   const { t } = useLanguage()
-  const [username, setUsername] = useState('')
-  const [email, setEmail] = useState('')
+  const currentUser = useUserStore((s) => s.user)
+  const [username, setUsername] = useState(currentUser?.username || '')
+  const [email, setEmail] = useState(currentUser?.email || '')
   const [age, setAge] = useState('')
   const [gender, setGender] = useState('')
   const [interests, setInterests] = useState('')


### PR DESCRIPTION
### Summary
- load current user's name and email from the store when editing profile

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e28403480833297eb32796c5fae36