### PR TITLE
[fix] show search history via backend

### DIFF
--- a/glancy-site/src/api/searchRecords.js
+++ b/glancy-site/src/api/searchRecords.js
@@ -1,0 +1,23 @@
+import { API_PATHS } from '../config/api.js'
+import { apiRequest } from './client.js'
+
+export const fetchSearchRecords = ({ userId, token }) =>
+  apiRequest(`${API_PATHS.searchRecords}/user/${userId}`, {
+    headers: { 'X-USER-TOKEN': token }
+  })
+
+export const saveSearchRecord = ({ userId, token, term, language }) =>
+  apiRequest(`${API_PATHS.searchRecords}/user/${userId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-USER-TOKEN': token
+    },
+    body: JSON.stringify({ term, language })
+  })
+
+export const clearSearchRecords = ({ userId, token }) =>
+  apiRequest(`${API_PATHS.searchRecords}/user/${userId}`, {
+    method: 'DELETE',
+    headers: { 'X-USER-TOKEN': token }
+  })

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,22 +1,23 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useLanguage } from '../../LanguageContext.jsx'
+import { useHistoryStore } from '../../store/historyStore.js'
+import { useUserStore } from '../../store/userStore.js'
 import './Sidebar.css'
 
 function HistoryList() {
-  const [history, setHistory] = useState([])
+  const history = useHistoryStore((s) => s.history)
+  const loadHistory = useHistoryStore((s) => s.loadHistory)
+  const user = useUserStore((s) => s.user)
   const { t } = useLanguage()
 
   useEffect(() => {
-    const stored = localStorage.getItem('searchHistory')
-    if (stored) {
-      setHistory(JSON.parse(stored))
-    }
-  }, [])
+    loadHistory(user)
+  }, [user, loadHistory])
 
   if (history.length === 0) return null
 
   return (
-    <div className="sidebar-section">
+    <div className="sidebar-section history-list">
       <h3>{t.searchHistory}</h3>
       <ul>
         {history.map((h, i) => (

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -40,6 +40,11 @@
   flex-direction: column;
 }
 
+.history-list {
+  max-height: 40vh;
+  overflow-y: auto;
+}
+
 .sidebar-user .user-menu button.with-name:hover {
 background-color: rgba(255, 255, 255, 0.1);
 border-radius: 4px;

--- a/glancy-site/src/components/Sidebar/SidebarFunctions.jsx
+++ b/glancy-site/src/components/Sidebar/SidebarFunctions.jsx
@@ -8,7 +8,7 @@ function SidebarFunctions() {
   return (
     <div className="sidebar-functions">
       {user && <Favorites />}
-      {user && <HistoryList />}
+      <HistoryList />
     </div>
   )
 }

--- a/glancy-site/src/config/api.js
+++ b/glancy-site/src/config/api.js
@@ -13,5 +13,6 @@ export const API_PATHS = {
   preferences: `${API_BASE}/preferences`,
   contact: `${API_BASE}/contact`,
   bindThirdParty: `${API_BASE}/bind/third-party`,
-  faqs: `${API_BASE}/faqs`
+  faqs: `${API_BASE}/faqs`,
+  searchRecords: `${API_BASE}/search-records`
 }

--- a/glancy-site/src/store/historyStore.js
+++ b/glancy-site/src/store/historyStore.js
@@ -1,0 +1,49 @@
+import { create } from 'zustand'
+import {
+  fetchSearchRecords,
+  saveSearchRecord,
+  clearSearchRecords
+} from '../api/searchRecords.js'
+
+const STORAGE_KEY = 'searchHistory'
+
+export const useHistoryStore = create((set, get) => {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  const initial = stored ? JSON.parse(stored) : []
+  return {
+    history: initial,
+    loadHistory: async (user) => {
+      if (user) {
+        try {
+          const records = await fetchSearchRecords({
+            userId: user.id,
+            token: user.token
+          })
+          const terms = records.map((r) => r.term)
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(terms))
+          set({ history: terms })
+        } catch {
+          // fallback to local storage
+        }
+      } else {
+        const stored = localStorage.getItem(STORAGE_KEY)
+        set({ history: stored ? JSON.parse(stored) : [] })
+      }
+    },
+    addHistory: async (term, user, language) => {
+      if (user) {
+        saveSearchRecord({ userId: user.id, token: user.token, term, language }).catch(() => {})
+      }
+      const unique = Array.from(new Set([term, ...get().history])).slice(0, 20)
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(unique))
+      set({ history: unique })
+    },
+    clearHistory: async (user) => {
+      if (user) {
+        clearSearchRecords({ userId: user.id, token: user.token }).catch(() => {})
+      }
+      localStorage.removeItem(STORAGE_KEY)
+      set({ history: [] })
+    }
+  }
+})


### PR DESCRIPTION
### Summary
- integrate search history API with new module
- fetch and update history in zustand store
- make history list container scrollable

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e249af86c8332a4b9091158eb3ea9