### PR TITLE
[fix] adjust dictionary entry styles

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -4,6 +4,7 @@ import MessagePopup from './components/MessagePopup.jsx'
 import { useUserStore } from './store/userStore.js'
 import { useTheme } from './ThemeContext.jsx'
 import { translations } from './translations.js'
+import DictionaryEntry from './components/DictionaryEntry.jsx'
 import sendLight from './assets/send-button-light.svg'
 import sendDark from './assets/send-button-dark.svg'
 import voiceLight from './assets/voice-button-light.svg'
@@ -17,14 +18,15 @@ import SidebarUser from './components/Sidebar/SidebarUser.jsx'
 
 function App() {
   const [text, setText] = useState('')
-  const [display, setDisplay] = useState(['What are we querying next?'])
+  const [entry, setEntry] = useState(null)
+  const placeholder = 'What are we querying next?'
   const [loading, setLoading] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
   const [popupOpen, setPopupOpen] = useState(false)
   const [popupMsg, setPopupMsg] = useState('')
   const user = useUserStore((s) => s.user)
   const { theme, resolvedTheme, setTheme } = useTheme()
-  const { lang, t, setLang } = useLanguage()
+  const { lang, setLang } = useLanguage()
   const inputRef = useRef(null)
   const sendIcon = resolvedTheme === 'dark' ? sendDark : sendLight
   const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
@@ -46,17 +48,7 @@ function App() {
         language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
         token: user.token
       })
-      const defs =
-        data.definition ||
-        (data.definitions && data.definitions.length > 0
-          ? data.definitions.join('; ')
-          : '')
-      const lines = [data.term]
-      if (data.phonetic) lines.push(`(${data.phonetic})`)
-      if (defs) lines.push(defs)
-      else lines.push(t.noDefinition)
-      if (data.example) lines.push(`"${data.example}"`)
-      setDisplay(lines)
+      setEntry(data)
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)
@@ -115,16 +107,11 @@ function App() {
         <main className="display">
           {loading ? (
             '...'
+          ) : entry ? (
+            <DictionaryEntry entry={entry} />
           ) : (
             <div className="display-content">
-              {display.map((line, idx) => (
-                <div
-                  key={idx}
-                  className={idx === 0 ? 'display-term' : undefined}
-                >
-                  {line}
-                </div>
-              ))}
+              <div className="display-term">{placeholder}</div>
             </div>
           )}
         </main>

--- a/glancy-site/src/components/DictionaryEntry.css
+++ b/glancy-site/src/components/DictionaryEntry.css
@@ -3,6 +3,9 @@
   margin: 0 auto;
   padding: 20px;
   border-bottom: 1px solid #eee;
+  text-align: left; /* override container centering */
+  font-size: 1rem;
+  font-weight: normal;
 }
 
 
@@ -14,15 +17,24 @@
 .termSection .sectionTitle {
   margin-top: 0;
 }
+.phoneticSection .sectionTitle {
+  margin: 8px 0 4px;
+}
+
+.termSection,
+.phoneticSection {
+  text-align: center;
+}
 
 .term {
-  font-size: 1.6em;
+  font-size: 1.8em;
   font-weight: bold;
   margin: 0;
 }
 
 .phonetic {
-  font-size: 0.9em;
+  font-size: 1em;
+  font-style: italic;
   color: #666;
   margin: 0;
 }
@@ -42,6 +54,7 @@
 
 .definitions li {
   margin-bottom: 0.6em;
+  font-size: 1em;
 }
 
 .example blockquote {
@@ -50,6 +63,7 @@
   border-left: 3px solid #ddd;
   font-style: italic;
   color: #555;
+  font-size: 1em;
 }
 
 .noDefinition {


### PR DESCRIPTION
### Summary
- improve DictionaryEntry styling so term and phonetic are centered
- make other sections left aligned with consistent font sizes

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e240159a48332a767b5de112c0d9f