### PR TITLE
[fix] remove unused search history headers

### DIFF
--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -78,7 +78,6 @@ function Search() {
       )}
       {history.length > 0 && (
         <div>
-          <h3>{t.searchHistory}</h3>
           <button onClick={() => clearHistory(user)}>{t.clearHistory}</button>
           <ul>
             {history.map((h, i) => (

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react'
-import { useLanguage } from '../../LanguageContext.jsx'
 import { useHistoryStore } from '../../store/historyStore.js'
 import { useUserStore } from '../../store/userStore.js'
 import './Sidebar.css'
@@ -8,7 +7,6 @@ function HistoryList() {
   const history = useHistoryStore((s) => s.history)
   const loadHistory = useHistoryStore((s) => s.loadHistory)
   const user = useUserStore((s) => s.user)
-  const { t } = useLanguage()
 
   useEffect(() => {
     loadHistory(user)
@@ -18,7 +16,6 @@ function HistoryList() {
 
   return (
     <div className="sidebar-section history-list">
-      <h3>{t.searchHistory}</h3>
       <ul>
         {history.map((h, i) => (
           <li key={i}>{h}</li>


### PR DESCRIPTION
### Summary
- remove unused `<h3>` labels for search history in Search page and sidebar

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e30dbb7d483328306dbeb4d0b84d0