### PR TITLE
[fix] remove expanded favorites list

### DIFF
--- a/glancy-site/src/components/Sidebar/Favorites.jsx
+++ b/glancy-site/src/components/Sidebar/Favorites.jsx
@@ -1,33 +1,18 @@
-import { useState } from 'react'
 import { useLanguage } from '../../LanguageContext.jsx'
-import { useFavoritesStore } from '../../store/favoritesStore.js'
 import './Sidebar.css'
 
 function Favorites({ onToggle }) {
   const { t } = useLanguage()
-  const favorites = useFavoritesStore((s) => s.favorites)
-  const [open, setOpen] = useState(false)
 
   const handleClick = () => {
-    const next = !open
-    setOpen(next)
-    if (onToggle) onToggle(next)
+    if (onToggle) onToggle((v) => !v)
   }
 
   return (
-    <div className={`sidebar-section favorites-list${open ? ' expanded' : ''}`}> 
+    <div className="sidebar-section favorites-list">
       <h3 className="collection-button" onClick={handleClick}>
         {t.favorites || 'Favorites'}
       </h3>
-      {open && (
-        <ul>
-          {favorites.length ? (
-            favorites.map((w, i) => <li key={i}>{w}</li>)
-          ) : (
-            <li>No favorites yet.</li>
-          )}
-        </ul>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
### Summary
- simplify Favorites component
- keep favorites as a button that toggles display

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e30b81ec88332bed868441b4290fe