### PR TITLE
[fix] center placeholder

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -64,7 +64,7 @@
   flex: 1;
   display: flex;
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   padding: 20px;
   overflow-y: auto;
   overscroll-behavior: contain;
@@ -77,6 +77,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  align-items: center;
 }
 
 .display-term {


### PR DESCRIPTION
### Summary
- center the placeholder text in App display area

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e34652a6c8332ab4c40a01d91d1bf