### PR TITLE
[feature] mobile topbar redesign

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -49,9 +49,10 @@
 .topbar {
   height: 60px;
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
   padding: 0 20px;
+  gap: 8px;
 }
 
 .avatar img {
@@ -121,18 +122,17 @@
     flex-direction: column;
   }
   .sidebar {
-    width: 100%;
-    height: auto;
-    padding: 10px;
+    display: none;
   }
   .sidebar-user {
     display: none;
   }
   .mobile-user-menu {
-    display: block;
+    display: none;
   }
   .topbar {
-    display: none;
+    display: flex;
+    padding: 10px;
   }
   .chatbox {
     padding: 16px;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -16,7 +16,9 @@ import './App.css'
 import Brand from './components/Brand.jsx'
 import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
 import SidebarUser from './components/Sidebar/SidebarUser.jsx'
-import { useFavoritesStore } from "./store/favoritesStore.js"
+import MobileTopBar from './components/MobileTopBar.jsx'
+import HistoryDisplay from './components/HistoryDisplay.jsx'
+import { useFavoritesStore } from './store/favoritesStore.js'
 
 function App() {
   const [text, setText] = useState('')
@@ -34,8 +36,19 @@ function App() {
   const sendIcon = resolvedTheme === 'dark' ? sendDark : sendLight
   const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
   const [showFavorites, setShowFavorites] = useState(false)
+  const [showHistory, setShowHistory] = useState(false)
   const favorites = useFavoritesStore((s) => s.favorites)
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
+
+  const handleToggleFavorites = () => {
+    setShowFavorites((v) => !v)
+    setShowHistory(false)
+  }
+
+  const handleToggleHistory = () => {
+    setShowHistory((v) => !v)
+    setShowFavorites(false)
+  }
 
   const handleSend = async (e) => {
     e.preventDefault()
@@ -109,11 +122,16 @@ function App() {
     <div className="container">
       <aside className="sidebar">
         <Brand />
-        <SidebarFunctions onToggleFavorites={setShowFavorites} />
+        <SidebarFunctions onToggleFavorites={handleToggleFavorites} />
         <SidebarUser />
       </aside>
       <div className="right">
-        <header className="topbar"></header>
+        <header className="topbar">
+          <MobileTopBar
+            onToggleFavorites={handleToggleFavorites}
+            onToggleHistory={handleToggleHistory}
+          />
+        </header>
         <main className="display">
           {showFavorites ? (
             favorites.length ? (
@@ -127,6 +145,8 @@ function App() {
                 <div className="display-term">{t.noFavorites || 'No favorites'}</div>
               </div>
             )
+          ) : showHistory ? (
+            <HistoryDisplay />
           ) : loading ? (
             '...'
           ) : entry ? (

--- a/glancy-site/src/components/HistoryDisplay.css
+++ b/glancy-site/src/components/HistoryDisplay.css
@@ -1,0 +1,8 @@
+.history-grid-display {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px 0;
+}

--- a/glancy-site/src/components/HistoryDisplay.jsx
+++ b/glancy-site/src/components/HistoryDisplay.jsx
@@ -1,0 +1,22 @@
+import { useHistoryStore } from '../store/historyStore.js'
+import './HistoryDisplay.css'
+
+function HistoryDisplay() {
+  const history = useHistoryStore((s) => s.history)
+  if (!history.length) {
+    return (
+      <div className="display-content">
+        <div className="display-term">No history</div>
+      </div>
+    )
+  }
+  return (
+    <ul className="history-grid-display">
+      {history.map((h, i) => (
+        <li key={i}>{h}</li>
+      ))}
+    </ul>
+  )
+}
+
+export default HistoryDisplay

--- a/glancy-site/src/components/MobileTopBar.css
+++ b/glancy-site/src/components/MobileTopBar.css
@@ -1,0 +1,12 @@
+.topbar-btn {
+  background: none;
+  border: none;
+  padding: 0 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+.topbar-text {
+  margin-left: auto;
+  font-size: 1.1rem;
+}

--- a/glancy-site/src/components/MobileTopBar.jsx
+++ b/glancy-site/src/components/MobileTopBar.jsx
@@ -1,0 +1,26 @@
+import { useTheme } from '../ThemeContext.jsx'
+import { useLanguage } from '../LanguageContext.jsx'
+import lightIcon from '../assets/glancy-light.svg'
+import darkIcon from '../assets/glancy-dark.svg'
+import UserMenu from './Header/UserMenu.jsx'
+import './MobileTopBar.css'
+
+function MobileTopBar({ onToggleFavorites, onToggleHistory }) {
+  const { resolvedTheme } = useTheme()
+  const { lang } = useLanguage()
+  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
+  const text = lang === 'zh' ? '格律词典' : 'Glancy'
+  return (
+    <>
+      <button className="topbar-btn" onClick={() => window.location.reload()}>
+        <img src={icon} alt="brand" width={24} height={24} />
+      </button>
+      <button className="topbar-btn" onClick={onToggleFavorites}>⭐</button>
+      <button className="topbar-btn" onClick={onToggleHistory}>📜</button>
+      <div className="topbar-btn"><UserMenu size={24} /></div>
+      <span className="topbar-text">{text}</span>
+    </>
+  )
+}
+
+export default MobileTopBar


### PR DESCRIPTION
### Summary
- hide sidebar on small screens and add new topbar layout
- add HistoryDisplay and MobileTopBar components

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e3570453c8332845c9cb4954a2cfe