### PR TITLE
[feature] enhance history list

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -76,6 +76,28 @@ function App() {
     }
   }
 
+  const handleSelectHistory = async (term) => {
+    if (!user) {
+      setModalOpen(true)
+      return
+    }
+    setLoading(true)
+    try {
+      const data = await fetchWord({
+        userId: user.id,
+        term,
+        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        token: user.token
+      })
+      setEntry(data)
+    } catch (err) {
+      setPopupMsg(err.message)
+      setPopupOpen(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   useEffect(() => {
     function handleShortcut(e) {
       const platform =
@@ -122,7 +144,10 @@ function App() {
     <div className="container">
       <aside className="sidebar">
         <Brand />
-        <SidebarFunctions onToggleFavorites={handleToggleFavorites} />
+        <SidebarFunctions
+          onToggleFavorites={handleToggleFavorites}
+          onSelectHistory={handleSelectHistory}
+        />
         <SidebarUser />
       </aside>
       <div className="right">

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,12 +1,16 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useHistoryStore } from '../../store/historyStore.js'
+import { useFavoritesStore } from '../../store/favoritesStore.js'
 import { useUserStore } from '../../store/userStore.js'
 import './Sidebar.css'
 
-function HistoryList() {
+function HistoryList({ onSelect }) {
   const history = useHistoryStore((s) => s.history)
   const loadHistory = useHistoryStore((s) => s.loadHistory)
+  const removeHistory = useHistoryStore((s) => s.removeHistory)
+  const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
   const user = useUserStore((s) => s.user)
+  const [openIndex, setOpenIndex] = useState(null)
 
   useEffect(() => {
     loadHistory(user)
@@ -18,7 +22,28 @@ function HistoryList() {
     <div className="sidebar-section history-list">
       <ul>
         {history.map((h, i) => (
-          <li key={i}>{h}</li>
+          <li key={i}>
+            <span className="history-term" onClick={() => onSelect && onSelect(h)}>
+              {h}
+            </span>
+            <button
+              type="button"
+              className="history-action"
+              onClick={() => setOpenIndex(openIndex === i ? null : i)}
+            >
+              ⋮
+            </button>
+            {openIndex === i && (
+              <div className="history-menu">
+                <button type="button" onClick={() => { toggleFavorite(h); setOpenIndex(null) }}>
+                  ★ 收藏
+                </button>
+                <button type="button" onClick={() => { removeHistory(h); setOpenIndex(null) }}>
+                  删除
+                </button>
+              </div>
+            )}
+          </li>
         ))}
       </ul>
     </div>

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -45,6 +45,52 @@
   overflow-y: auto;
 }
 
+.history-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  position: relative;
+}
+
+.history-term {
+  cursor: pointer;
+}
+
+.history-action {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  padding: 0 4px;
+}
+
+.history-menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  z-index: 10;
+}
+
+.history-menu button {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+}
+
+.history-menu button:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
 .sidebar-user .user-menu button.with-name:hover {
 background-color: rgba(255, 255, 255, 0.1);
 border-radius: 4px;

--- a/glancy-site/src/components/Sidebar/SidebarFunctions.jsx
+++ b/glancy-site/src/components/Sidebar/SidebarFunctions.jsx
@@ -3,12 +3,12 @@ import HistoryList from './HistoryList.jsx'
 import { useUserStore } from '../../store/userStore.js'
 import './Sidebar.css'
 
-function SidebarFunctions({ onToggleFavorites }) {
+function SidebarFunctions({ onToggleFavorites, onSelectHistory }) {
   const user = useUserStore((s) => s.user)
   return (
     <div className="sidebar-functions">
       {user && <Favorites onToggle={onToggleFavorites} />}
-      <HistoryList />
+      <HistoryList onSelect={onSelectHistory} />
     </div>
   )
 }

--- a/glancy-site/src/store/historyStore.js
+++ b/glancy-site/src/store/historyStore.js
@@ -44,6 +44,11 @@ export const useHistoryStore = create((set, get) => {
       }
       localStorage.removeItem(STORAGE_KEY)
       set({ history: [] })
+    },
+    removeHistory: (term) => {
+      const updated = get().history.filter((t) => t !== term)
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated))
+      set({ history: updated })
     }
   }
 })


### PR DESCRIPTION
### Summary
- make sidebar history items clickable with action menu
- allow removing history items and toggling favorites

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e381f80908332a87a69d06b46dc8e