### PR TITLE
[fix] mobile top bar visibility

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -48,7 +48,7 @@
 
 .topbar {
   height: 60px;
-  display: flex;
+  display: none;
   justify-content: flex-start;
   align-items: center;
   padding: 0 20px;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -13,6 +13,7 @@ import voiceDark from './assets/voice-button-dark.svg'
 import { fetchWord } from './api/words.js'
 import { useLanguage } from './LanguageContext.jsx'
 import './App.css'
+import { useIsMobile } from './utils.js'
 import Brand from './components/Brand.jsx'
 import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
 import SidebarUser from './components/Sidebar/SidebarUser.jsx'
@@ -39,6 +40,7 @@ function App() {
   const [showHistory, setShowHistory] = useState(false)
   const favorites = useFavoritesStore((s) => s.favorites)
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
+  const isMobile = useIsMobile()
 
   const handleToggleFavorites = () => {
     setShowFavorites((v) => !v)
@@ -126,12 +128,14 @@ function App() {
         <SidebarUser />
       </aside>
       <div className="right">
-        <header className="topbar">
-          <MobileTopBar
-            onToggleFavorites={handleToggleFavorites}
-            onToggleHistory={handleToggleHistory}
-          />
-        </header>
+        {isMobile && (
+          <header className="topbar">
+            <MobileTopBar
+              onToggleFavorites={handleToggleFavorites}
+              onToggleHistory={handleToggleHistory}
+            />
+          </header>
+        )}
         <main className="display">
           {showFavorites ? (
             favorites.length ? (

--- a/glancy-site/src/components/MobileTopBar.css
+++ b/glancy-site/src/components/MobileTopBar.css
@@ -7,6 +7,7 @@
   align-items: center;
 }
 .topbar-text {
-  margin-left: auto;
+  margin-left: 8px;
+  margin-right: auto;
   font-size: 1.1rem;
 }

--- a/glancy-site/src/components/MobileTopBar.jsx
+++ b/glancy-site/src/components/MobileTopBar.jsx
@@ -15,10 +15,10 @@ function MobileTopBar({ onToggleFavorites, onToggleHistory }) {
       <button className="topbar-btn" onClick={() => window.location.reload()}>
         <img src={icon} alt="brand" width={24} height={24} />
       </button>
+      <span className="topbar-text">{text}</span>
       <button className="topbar-btn" onClick={onToggleFavorites}>⭐</button>
       <button className="topbar-btn" onClick={onToggleHistory}>📜</button>
       <div className="topbar-btn"><UserMenu size={24} /></div>
-      <span className="topbar-text">{text}</span>
     </>
   )
 }

--- a/glancy-site/src/utils.js
+++ b/glancy-site/src/utils.js
@@ -1,3 +1,5 @@
+import { useState, useEffect } from 'react'
+
 export function extractMessage(text) {
   if (!text) return ''
   try {
@@ -15,4 +17,20 @@ export function getModifierKey() {
   const platform =
     navigator.userAgentData?.platform || navigator.platform || ''
   return /Mac|iPhone|iPod|iPad/i.test(platform) ? 'Command \u2318' : 'Ctrl \u2303'
+}
+
+export function useIsMobile(maxWidth = 600) {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth <= maxWidth : false
+  )
+
+  useEffect(() => {
+    function handleResize() {
+      setIsMobile(window.innerWidth <= maxWidth)
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [maxWidth])
+
+  return isMobile
 }


### PR DESCRIPTION
### Summary
- add `useIsMobile` hook
- only render MobileTopBar on small screens

### Testing
- `npm ci` *(fails: npm not found)*
- `npm run lint` *(not run)*
- `npm run build` *(not run)*


------
https://chatgpt.com/codex/tasks/task_e_687e382a9cf0833297dcf08337acd290