### PR TITLE
[feature] integrate favorite API

### DIFF
--- a/glancy-site/src/api/searchRecords.js
+++ b/glancy-site/src/api/searchRecords.js
@@ -21,3 +21,12 @@ export const clearSearchRecords = ({ userId, token }) =>
     method: 'DELETE',
     headers: { 'X-USER-TOKEN': token }
   })
+
+export const favoriteSearchRecord = ({ userId, token, recordId }) =>
+  apiRequest(
+    `${API_PATHS.searchRecords}/user/${userId}/${recordId}/favorite`,
+    {
+      method: 'POST',
+      headers: { 'X-USER-TOKEN': token }
+    }
+  )

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -9,6 +9,7 @@ function HistoryList({ onSelect }) {
   const loadHistory = useHistoryStore((s) => s.loadHistory)
   const removeHistory = useHistoryStore((s) => s.removeHistory)
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
+  const favoriteHistory = useHistoryStore((s) => s.favoriteHistory)
   const user = useUserStore((s) => s.user)
   const [openIndex, setOpenIndex] = useState(null)
 
@@ -35,7 +36,14 @@ function HistoryList({ onSelect }) {
             </button>
             {openIndex === i && (
               <div className="history-menu">
-                <button type="button" onClick={() => { toggleFavorite(h); setOpenIndex(null) }}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    favoriteHistory(h, user)
+                    toggleFavorite(h)
+                    setOpenIndex(null)
+                  }}
+                >
                   ★ 收藏
                 </button>
                 <button type="button" onClick={() => { removeHistory(h); setOpenIndex(null) }}>


### PR DESCRIPTION
### Summary
- call `/user/{id}/{recordId}/favorite` when favoriting history
- track record ids in history store

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e3b991e908332aa564fc03a95c262