### PR TITLE
[feature] support deleting single search record

### DIFF
--- a/glancy-site/src/api/searchRecords.js
+++ b/glancy-site/src/api/searchRecords.js
@@ -21,3 +21,9 @@ export const clearSearchRecords = ({ userId, token }) =>
     method: 'DELETE',
     headers: { 'X-USER-TOKEN': token }
   })
+
+export const deleteSearchRecord = ({ userId, recordId, token }) =>
+  apiRequest(`${API_PATHS.searchRecords}/user/${userId}/${recordId}`, {
+    method: 'DELETE',
+    headers: { 'X-USER-TOKEN': token }
+  })

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -38,7 +38,7 @@ function HistoryList({ onSelect }) {
                 <button type="button" onClick={() => { toggleFavorite(h); setOpenIndex(null) }}>
                   ★ 收藏
                 </button>
-                <button type="button" onClick={() => { removeHistory(h); setOpenIndex(null) }}>
+                <button type="button" onClick={() => { removeHistory(h, user); setOpenIndex(null) }}>
                   删除
                 </button>
               </div>


### PR DESCRIPTION
### Summary
- add `deleteSearchRecord` api call
- remove history entry via backend when user clicks delete

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e3c6511308332a75e6ab028ad5e78