### PR TITLE
[fix] adjust history menu direction

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -67,8 +67,8 @@
 
 .history-menu {
   position: absolute;
-  right: 0;
-  top: 100%;
+  left: 100%;
+  top: 0;
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);


### PR DESCRIPTION
### Summary
- make the history item action menu open to the right rather than downward

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e3d19f48c8332bd75ae7c19bc30b9