### PR TITLE
[feature] add unfavorite api and ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ export default defineConfig({
 实际请求需在头部加入 `X-USER-TOKEN`。点击播放按钮访问
 `/api/words/audio?word=xxx` 播放语音。
 
+## Search Record Endpoints
+- `POST /api/search-records/user/{userId}` – add a new search record for the user
+- `GET /api/search-records/user/{userId}` – list search records of the user
+- `DELETE /api/search-records/user/{userId}` – clear all search records of the user
+- `DELETE /api/search-records/user/{userId}/{recordId}/favorite` – unfavorite a search record
+  以上接口均需在 `X-USER-TOKEN` 请求头中提供登录令牌
+
 ## 通知中心
 
 `/notifications` 页面通过 `GET /api/notifications` 获取通知列表，标记已读时调

--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -159,3 +159,21 @@
   cursor: pointer;
   font-size: 1.5rem;
 }
+
+.favorite-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.unfavorite-btn {
+  background: none;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  margin-left: 6px;
+  cursor: pointer;
+  line-height: 1;
+}

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -40,6 +40,7 @@ function App() {
   const [showHistory, setShowHistory] = useState(false)
   const favorites = useFavoritesStore((s) => s.favorites)
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
+  const unfavoriteHistory = useHistoryStore((s) => s.unfavoriteHistory)
   const isMobile = useIsMobile()
 
   const handleToggleFavorites = () => {
@@ -50,6 +51,11 @@ function App() {
   const handleToggleHistory = () => {
     setShowHistory((v) => !v)
     setShowFavorites(false)
+  }
+
+  const handleUnfavorite = (term) => {
+    unfavoriteHistory(term, user)
+    toggleFavorite(term)
   }
 
   const handleSend = async (e) => {
@@ -166,7 +172,16 @@ function App() {
             favorites.length ? (
               <ul className="favorites-grid-display">
                 {favorites.map((w, i) => (
-                  <li key={i}>{w}</li>
+                  <li key={i} className="favorite-item">
+                    {w}
+                    <button
+                      type="button"
+                      className="unfavorite-btn"
+                      onClick={() => handleUnfavorite(w)}
+                    >
+                      ○
+                    </button>
+                  </li>
                 ))}
               </ul>
             ) : (

--- a/glancy-site/src/api/searchRecords.js
+++ b/glancy-site/src/api/searchRecords.js
@@ -36,3 +36,12 @@ export const favoriteSearchRecord = ({ userId, token, recordId }) =>
       headers: { 'X-USER-TOKEN': token }
     }
   )
+
+export const unfavoriteSearchRecord = ({ userId, token, recordId }) =>
+  apiRequest(
+    `${API_PATHS.searchRecords}/user/${userId}/${recordId}/favorite`,
+    {
+      method: 'DELETE',
+      headers: { 'X-USER-TOKEN': token }
+    }
+  )

--- a/glancy-site/src/store/historyStore.js
+++ b/glancy-site/src/store/historyStore.js
@@ -3,8 +3,9 @@ import {
   fetchSearchRecords,
   saveSearchRecord,
   clearSearchRecords,
-  deleteSearchRecord，
-  favoriteSearchRecord
+  deleteSearchRecord,
+  favoriteSearchRecord,
+  unfavoriteSearchRecord
 } from '../api/searchRecords.js'
 
 const STORAGE_KEY = 'searchHistory'
@@ -16,7 +17,6 @@ export const useHistoryStore = create((set, get) => {
   return {
     history: initial,
     recordMap: initialMap,
-    recordMap: {},
     loadHistory: async (user) => {
       if (user) {
         try {
@@ -75,11 +75,17 @@ export const useHistoryStore = create((set, get) => {
         return { history: updated, recordMap: map }
       })
     },
-    favoriteHistory: async (term, user) => {
-      const id = get().recordMap[term]
-      if (user && id) {
-        favoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch(() => {})
+      favoriteHistory: async (term, user) => {
+        const id = get().recordMap[term]
+        if (user && id) {
+          favoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch(() => {})
+        }
+      },
+      unfavoriteHistory: async (term, user) => {
+        const id = get().recordMap[term]
+        if (user && id) {
+          unfavoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch(() => {})
+        }
       }
     }
-  }
-})
+  })


### PR DESCRIPTION
### Summary
- document unfavorite search record endpoint
- support unfavoriting a record via API
- expose unfavorite action in history store
- add unfavorite button in favorites list

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e3ed2b3ec8332ba0e2c837b151146