### PR TITLE
[fix] avoid reordering history

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -100,7 +100,7 @@ function App() {
         token: user.token
       })
       setEntry(data)
-      addHistory(term, user, lang === 'zh' ? 'CHINESE' : 'ENGLISH')
+      // selecting from history should not reorder records
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)

--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -23,7 +23,7 @@ function Search() {
     loadHistory(user)
   }, [user, loadHistory])
 
-  const searchTerm = async (term) => {
+  const searchTerm = async (term, updateHistory = true) => {
     setPopupMsg('')
     try {
       const data = await fetchWord({
@@ -33,7 +33,9 @@ function Search() {
         token: user?.token
       })
       setResult(data)
-      addHistory(term, user, lang === 'zh' ? 'CHINESE' : 'ENGLISH')
+      if (updateHistory) {
+        addHistory(term, user, lang === 'zh' ? 'CHINESE' : 'ENGLISH')
+      }
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)
@@ -47,7 +49,7 @@ function Search() {
 
   const handleHistoryClick = (term) => {
     setWord(term)
-    searchTerm(term)
+    searchTerm(term, false)
   }
 
   const playAudio = async () => {

--- a/glancy-site/src/store/historyStore.js
+++ b/glancy-site/src/store/historyStore.js
@@ -6,7 +6,7 @@ import {
   deleteSearchRecord,
   favoriteSearchRecord,
   unfavoriteSearchRecord,
-  favoriteSearchRecord
+  
 } from '../api/searchRecords.js'
 
 const STORAGE_KEY = 'searchHistory'


### PR DESCRIPTION
### Summary
- prevent history list selection from reordering search terms
- fix duplicate import in history store

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e4118d888833297c9b723c568cd1e