### PR TITLE
[fix] menu positioning

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -67,13 +67,13 @@
 
 .history-menu {
   position: absolute;
-  left: 100%;
-  top: 0;
+  right: 0;
+  top: 100%;
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);
   border-radius: 4px;
-  z-index: 10;
+  z-index: 100;
 }
 
 .history-menu button {


### PR DESCRIPTION
### Summary
- fix history menu dropdown not visible by repositioning it under the action button

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e43c5c8d4833295befc8cdca235fa