### PR TITLE
[fix] always show favorites page

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -45,7 +45,8 @@ function App() {
   const isMobile = useIsMobile()
 
   const handleToggleFavorites = () => {
-    setShowFavorites((v) => !v)
+    // always show favorites when invoked
+    setShowFavorites(true)
     setShowHistory(false)
   }
 


### PR DESCRIPTION
### Summary
- disable toggling on favorites button so the page remains visible

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e43bd811c8332bd31ae706de118f6