### PR TITLE
[fix] extend sidebar lists

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -41,7 +41,7 @@
 }
 
 .history-list {
-  max-height: 40vh;
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -105,8 +105,8 @@ border-radius: 4px;
   list-style: none;
   padding: 0;
   margin: 0;
-  max-height: 40vh;
   overflow-y: auto;
+  flex: 1;
 }
 
 .collection-button {


### PR DESCRIPTION
### Summary
- let sidebar history list stretch to fill available space

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e4d71171883328023b4a77ea91e1b