### PR TITLE
[fix] adjust history menu position

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -27,30 +27,32 @@ function HistoryList({ onSelect }) {
             <span className="history-term" onClick={() => onSelect && onSelect(h)}>
               {h}
             </span>
-            <button
-              type="button"
-              className="history-action"
-              onClick={() => setOpenIndex(openIndex === i ? null : i)}
-            >
-              ⋮
-            </button>
-            {openIndex === i && (
-              <div className="history-menu">
-                <button
-                  type="button"
-                  onClick={() => {
-                    favoriteHistory(h, user)
-                    toggleFavorite(h)
-                    setOpenIndex(null)
-                  }}
-                >
-                  ★ 收藏
-                </button>
-                <button type="button" onClick={() => { removeHistory(h, user); setOpenIndex(null) }}>
-                  删除
-                </button>
-              </div>
-            )}
+            <div className="history-action-wrapper">
+              <button
+                type="button"
+                className="history-action"
+                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+              >
+                ⋮
+              </button>
+              {openIndex === i && (
+                <div className="history-menu">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      favoriteHistory(h, user)
+                      toggleFavorite(h)
+                      setOpenIndex(null)
+                    }}
+                  >
+                    ★ 收藏
+                  </button>
+                  <button type="button" onClick={() => { removeHistory(h, user); setOpenIndex(null) }}>
+                    删除
+                  </button>
+                </div>
+              )}
+            </div>
           </li>
         ))}
       </ul>

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -57,6 +57,11 @@
   cursor: pointer;
 }
 
+.history-action-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
 .history-action {
   background: none;
   border: none;
@@ -68,7 +73,7 @@
 .history-menu {
   position: absolute;
   right: 0;
-  top: 100%;
+  top: calc(100% + 4px);
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);


### PR DESCRIPTION
### Summary
- wrap history actions in a relative container
- align the history dropdown below the action button

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e4ccb13ec8332b2b5d3f250c172b4