### PR TITLE
[feature] add desktop topbar

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -172,6 +172,10 @@
   color: var(--app-color);
 }
 
+.favorite-term {
+  cursor: pointer;
+}
+
 .unfavorite-btn {
   background: none;
   border: 1px solid currentColor;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -18,6 +18,7 @@ import Brand from './components/Brand.jsx'
 import SidebarFunctions from './components/Sidebar/SidebarFunctions.jsx'
 import SidebarUser from './components/Sidebar/SidebarUser.jsx'
 import MobileTopBar from './components/MobileTopBar.jsx'
+import DesktopTopBar from './components/DesktopTopBar.jsx'
 import HistoryDisplay from './components/HistoryDisplay.jsx'
 import { useFavoritesStore } from './store/favoritesStore.js'
 
@@ -39,6 +40,7 @@ function App() {
   const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
   const [showFavorites, setShowFavorites] = useState(false)
   const [showHistory, setShowHistory] = useState(false)
+  const [fromFavorites, setFromFavorites] = useState(false)
   const favorites = useFavoritesStore((s) => s.favorites)
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
   const unfavoriteHistory = useHistoryStore((s) => s.unfavoriteHistory)
@@ -48,16 +50,29 @@ function App() {
     // always show favorites when invoked
     setShowFavorites(true)
     setShowHistory(false)
+    setFromFavorites(false)
   }
 
   const handleToggleHistory = () => {
     setShowHistory((v) => !v)
     setShowFavorites(false)
+    setFromFavorites(false)
   }
 
   const handleUnfavorite = (term) => {
     unfavoriteHistory(term, user)
     toggleFavorite(term)
+  }
+
+  const handleSelectFavorite = async (term) => {
+    await handleSelectHistory(term)
+    setShowFavorites(false)
+    setFromFavorites(true)
+  }
+
+  const handleBackFromFavorite = () => {
+    setShowFavorites(true)
+    setFromFavorites(false)
   }
 
   const handleSend = async (e) => {
@@ -163,13 +178,19 @@ function App() {
         <SidebarUser />
       </aside>
       <div className="right">
-        {isMobile && (
+        {isMobile ? (
           <header className="topbar">
             <MobileTopBar
               onToggleFavorites={handleToggleFavorites}
               onToggleHistory={handleToggleHistory}
             />
           </header>
+        ) : (
+          <DesktopTopBar
+            term={entry?.term || ''}
+            showBack={!showFavorites && fromFavorites}
+            onBack={handleBackFromFavorite}
+          />
         )}
         <main className="display">
           {showFavorites ? (
@@ -177,7 +198,12 @@ function App() {
               <ul className="favorites-grid-display">
                 {favorites.map((w, i) => (
                   <li key={i} className="favorite-item">
-                    {w}
+                    <span
+                      className="favorite-term"
+                      onClick={() => handleSelectFavorite(w)}
+                    >
+                      {w}
+                    </span>
                     <button
                       type="button"
                       className="unfavorite-btn"

--- a/glancy-site/src/components/DesktopTopBar.css
+++ b/glancy-site/src/components/DesktopTopBar.css
@@ -1,0 +1,54 @@
+.desktop-topbar {
+  height: 60px;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  gap: 8px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.term-text {
+  flex: 1;
+  text-align: center;
+  font-weight: bold;
+}
+
+.back-btn,
+.more-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 8px;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+}
+
+.more-menu {
+  position: relative;
+}
+
+.more-menu .menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: var(--app-bg);
+  color: var(--app-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 4px 0;
+  width: 100px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.more-menu .menu button {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  text-align: left;
+  cursor: pointer;
+}

--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -1,0 +1,51 @@
+import { useState, useRef, useEffect } from 'react'
+import ModelSelector from './Toolbar/ModelSelector.jsx'
+import './DesktopTopBar.css'
+
+function DesktopTopBar({ term = '', showBack = false, onBack }) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    function handlePointerDown(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown)
+    }
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [open])
+
+  return (
+    <header className="desktop-topbar">
+      {showBack && (
+        <button type="button" className="back-btn" onClick={onBack}>
+          ←
+        </button>
+      )}
+      <div className="term-text">{term}</div>
+      <div className="topbar-right">
+        <ModelSelector />
+        <div className="more-menu" ref={menuRef}>
+          <button
+            type="button"
+            className="more-btn"
+            onClick={() => setOpen(!open)}
+          >
+            ⋮
+          </button>
+          {open && (
+            <div className="menu">
+              <button type="button">Share</button>
+              <button type="button">Report</button>
+            </div>
+          )}
+        </div>
+      </div>
+    </header>
+  )
+}
+
+export default DesktopTopBar


### PR DESCRIPTION
### Summary
- implement desktop topbar with model selector and menu
- enable favorites click to show detail and back button

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e4eccefec8332ae79442632c4d249