### PR TITLE
[feature] add delete icon to history menu

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -47,8 +47,15 @@ function HistoryList({ onSelect }) {
                   >
                     ★ 收藏
                   </button>
-                  <button type="button" onClick={() => { removeHistory(h, user); setOpenIndex(null) }}>
-                    删除
+                  <button
+                    type="button"
+                    className="delete-btn"
+                    onClick={() => {
+                      removeHistory(h, user)
+                      setOpenIndex(null)
+                    }}
+                  >
+                    🗑 删除
                   </button>
                 </div>
               )}

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -96,6 +96,10 @@
   background: rgba(255, 255, 255, 0.1);
 }
 
+.history-menu .delete-btn {
+  color: #e34343;
+}
+
 .sidebar-user .user-menu button.with-name:hover {
 background-color: rgba(255, 255, 255, 0.1);
 border-radius: 4px;


### PR DESCRIPTION
### Summary
- add trash icon before the delete entry
- show delete option in red in history menu

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e4f86024c8332a7a976299d26d9d3