### PR TITLE
[feature] move favorite button

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -196,6 +196,10 @@ function App() {
             term={entry?.term || ''}
             showBack={!showFavorites && fromFavorites}
             onBack={handleBackFromFavorite}
+            favorited={favorites.includes(entry?.term)}
+            onToggleFavorite={() =>
+              entry && toggleFavorite(entry.term)
+            }
           />
         )}
         <main className="display">
@@ -230,12 +234,7 @@ function App() {
           ) : loading ? (
             '...'
           ) : entry ? (
-            <div className="result">
-              <DictionaryEntry entry={entry} />
-              <button className="favorite-toggle" onClick={() => toggleFavorite(entry.term)}>
-                {favorites.includes(entry.term) ? '★' : '☆'}
-              </button>
-            </div>
+            <DictionaryEntry entry={entry} />
           ) : (
             <div className="display-content">
               <div className="display-term">{placeholder}</div>

--- a/glancy-site/src/components/DesktopTopBar.css
+++ b/glancy-site/src/components/DesktopTopBar.css
@@ -26,6 +26,11 @@
   align-items: center;
 }
 
+.topbar-right .favorite-toggle {
+  margin-top: 0;
+  margin-right: 8px;
+}
+
 .more-menu {
   position: relative;
 }

--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -2,7 +2,13 @@ import { useState, useRef, useEffect } from 'react'
 import ModelSelector from './Toolbar/ModelSelector.jsx'
 import './DesktopTopBar.css'
 
-function DesktopTopBar({ term = '', showBack = false, onBack }) {
+function DesktopTopBar({
+  term = '',
+  showBack = false,
+  onBack,
+  favorited = false,
+  onToggleFavorite
+}) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
 
@@ -27,6 +33,13 @@ function DesktopTopBar({ term = '', showBack = false, onBack }) {
       )}
       <div className="term-text">{term}</div>
       <div className="topbar-right">
+        <button
+          type="button"
+          className="favorite-toggle"
+          onClick={onToggleFavorite}
+        >
+          {favorited ? '★' : '☆'}
+        </button>
         <ModelSelector />
         <div className="more-menu" ref={menuRef}>
           <button

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -160,12 +160,3 @@ button:focus-visible {
   background-color: transparent;
 }
 
-.result {
-  margin-top: 1rem;
-  padding: 1rem;
-  border: 1px solid var(--border-color);
-  border-radius: 8px;
-}
-.result h4 {
-  margin: 0.5rem 0;
-}


### PR DESCRIPTION
### Summary
- remove result wrapper so DictionaryEntry takes the whole display
- move favorite toggle to DesktopTopBar beside model selector

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e50c79be48332837eba395d7a4ba7