### PR TITLE
[fix] reset topbar term on favorites back

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -73,6 +73,7 @@ function App() {
   const handleBackFromFavorite = () => {
     setShowFavorites(true)
     setFromFavorites(false)
+    setEntry(null)
   }
 
   const handleSend = async (e) => {


### PR DESCRIPTION
### Summary
- clear selected entry when returning from favorites so the top bar term disappears

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e51c259988332a5f13827cbf56068