### PR TITLE
[fix] top bar center issue

### DIFF
--- a/glancy-site/src/components/DesktopTopBar.css
+++ b/glancy-site/src/components/DesktopTopBar.css
@@ -8,7 +8,6 @@
 }
 
 .term-text {
-  flex: 1;
   text-align: center;
   font-weight: bold;
 }
@@ -24,6 +23,7 @@
 .topbar-right {
   display: flex;
   align-items: center;
+  margin-left: auto;
 }
 
 .more-menu {


### PR DESCRIPTION
### Summary
- keep `.term-text` width to content and push right section with `margin-left:auto`

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_687e516294c483329971d45d9f06c5fa