### PR TITLE
[fix] hide favorite button when no entry

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -198,9 +198,8 @@ function App() {
             showBack={!showFavorites && fromFavorites}
             onBack={handleBackFromFavorite}
             favorited={favorites.includes(entry?.term)}
-            onToggleFavorite={() =>
-              entry && toggleFavorite(entry.term)
-            }
+            onToggleFavorite={() => entry && toggleFavorite(entry.term)}
+            canFavorite={!!entry && !showFavorites && !showHistory}
           />
         )}
         <main className="display">

--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -7,7 +7,8 @@ function DesktopTopBar({
   showBack = false,
   onBack,
   favorited = false,
-  onToggleFavorite
+  onToggleFavorite,
+  canFavorite = false
 }) {
   const [open, setOpen] = useState(false)
   const menuRef = useRef(null)
@@ -33,13 +34,15 @@ function DesktopTopBar({
       )}
       <div className="term-text">{term}</div>
       <div className="topbar-right">
-        <button
-          type="button"
-          className="favorite-toggle"
-          onClick={onToggleFavorite}
-        >
-          {favorited ? '★' : '☆'}
-        </button>
+        {canFavorite && (
+          <button
+            type="button"
+            className="favorite-toggle"
+            onClick={onToggleFavorite}
+          >
+            {favorited ? '★' : '☆'}
+          </button>
+        )}
         <ModelSelector />
         <div className="more-menu" ref={menuRef}>
           <button


### PR DESCRIPTION
### Summary
- hide favorite toggle in DesktopTopBar when no entry is shown
- pass `canFavorite` flag from App

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e52be7ec883329f2c96fd0c3d71c7