### PR TITLE
[feature] highlight history items

### DIFF
--- a/glancy-site/src/components/HistoryDisplay.css
+++ b/glancy-site/src/components/HistoryDisplay.css
@@ -6,3 +6,17 @@
   margin: 0 auto;
   padding: 20px 0;
 }
+
+.history-grid-display li {
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.history-grid-display li:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+:root[data-theme='dark'] .history-grid-display li:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -51,6 +51,15 @@
   align-items: center;
   padding: 4px 0;
   position: relative;
+  border-radius: 4px;
+}
+
+.history-list li:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+:root[data-theme='dark'] .history-list li:hover {
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 .history-term {


### PR DESCRIPTION
### Summary
- add hover highlight to history grid
- style sidebar history items with hover effect

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e53ba8f788332b2d4dc2f941faf03