### PR TITLE
[feature] add icons to menu buttons

### DIFF
--- a/glancy-site/src/components/DesktopTopBar.css
+++ b/glancy-site/src/components/DesktopTopBar.css
@@ -57,3 +57,7 @@
   text-align: left;
   cursor: pointer;
 }
+
+.more-menu .menu .icon {
+  margin-right: 4px;
+}

--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -54,8 +54,12 @@ function DesktopTopBar({
           </button>
           {open && (
             <div className="menu">
-              <button type="button">Share</button>
-              <button type="button">Report</button>
+              <button type="button">
+                <span className="icon">🔗</span>Share
+              </button>
+              <button type="button">
+                <span className="icon">🚩</span>Report
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
### Summary
- prepend emoji icons to Share and Report buttons in DesktopTopBar menu
- add icon margin styling

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e56619fd88332a826e387e1e84316