### PR TITLE
[fix] history click area

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -36,15 +36,18 @@ function HistoryList({ onSelect }) {
     <div className="sidebar-section history-list" ref={listRef}>
       <ul>
         {history.map((h, i) => (
-          <li key={i}>
-            <span className="history-term" onClick={() => onSelect && onSelect(h)}>
+          <li key={i} onClick={() => onSelect && onSelect(h)}>
+            <span className="history-term">
               {h}
             </span>
             <div className="history-action-wrapper">
               <button
                 type="button"
                 className="history-action"
-                onClick={() => setOpenIndex(openIndex === i ? null : i)}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setOpenIndex(openIndex === i ? null : i)
+                }}
               >
                 ⋮
               </button>
@@ -52,7 +55,8 @@ function HistoryList({ onSelect }) {
                 <div className="history-menu">
                   <button
                     type="button"
-                    onClick={() => {
+                    onClick={(e) => {
+                      e.stopPropagation()
                       favoriteHistory(h, user)
                       toggleFavorite(h)
                       setOpenIndex(null)
@@ -63,7 +67,8 @@ function HistoryList({ onSelect }) {
                   <button
                     type="button"
                     className="delete-btn"
-                    onClick={() => {
+                    onClick={(e) => {
+                      e.stopPropagation()
                       removeHistory(h, user)
                       setOpenIndex(null)
                     }}

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -52,6 +52,7 @@
   padding: 4px 0;
   position: relative;
   border-radius: 4px;
+  cursor: pointer;
 }
 
 .history-list li:hover {
@@ -63,7 +64,6 @@
 }
 
 .history-term {
-  cursor: pointer;
 }
 
 .history-action-wrapper {


### PR DESCRIPTION
### Summary
- expand history item click area to entire row
- stop propagation on menu buttons

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e575c58748332a7ccaf9d07a10188