### PR TITLE
[fix] adjust history padding

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -50,6 +50,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 4px 0;
+  padding-left: 8px;
   position: relative;
   border-radius: 4px;
 }


### PR DESCRIPTION
### Summary
- add left padding for history list items

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e571629d48332b50c9d5b4ec1e107