### PR TITLE
[fix] highlight favorites

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -131,4 +131,15 @@ border-radius: 4px;
 .collection-button {
   cursor: pointer;
   user-select: none;
+  padding: 4px 0;
+  padding-left: 8px;
+  border-radius: 4px;
+}
+
+.collection-button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+:root[data-theme='dark'] .collection-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
### Summary
- make Favorites hover highlight same as search history

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e58903c748332bb5c19a7fcd5774d