### PR TITLE
[refactor] mobile layout overhaul

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -123,10 +123,17 @@
     flex-direction: column;
   }
   .sidebar {
-    display: none;
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    width: 240px;
   }
-  .sidebar-user {
-    display: none;
+  .sidebar.mobile-open {
+    transform: translateX(0);
   }
   .mobile-user-menu {
     display: none;
@@ -138,6 +145,13 @@
   .chatbox {
     padding: 16px;
   }
+}
+
+.sidebar-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 999;
 }
 
 .App h2 {

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -45,6 +45,7 @@ function App() {
   const toggleFavorite = useFavoritesStore((s) => s.toggleFavorite)
   const unfavoriteHistory = useHistoryStore((s) => s.unfavoriteHistory)
   const isMobile = useIsMobile()
+  const [sidebarOpen, setSidebarOpen] = useState(false)
 
   const handleToggleFavorites = () => {
     // always show favorites when invoked
@@ -53,11 +54,6 @@ function App() {
     setFromFavorites(false)
   }
 
-  const handleToggleHistory = () => {
-    setShowHistory((v) => !v)
-    setShowFavorites(false)
-    setFromFavorites(false)
-  }
 
   const handleUnfavorite = (term) => {
     unfavoriteHistory(term, user)
@@ -176,7 +172,15 @@ function App() {
 
   return (
     <div className="container">
-      <aside className="sidebar">
+      {isMobile && sidebarOpen && (
+        <div
+          className="sidebar-overlay"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+      <aside
+        className={`sidebar${isMobile ? (sidebarOpen ? ' mobile-open' : '') : ''}`}
+      >
         <Brand />
         <SidebarFunctions
           onToggleFavorites={handleToggleFavorites}
@@ -188,8 +192,13 @@ function App() {
         {isMobile ? (
           <header className="topbar">
             <MobileTopBar
-              onToggleFavorites={handleToggleFavorites}
-              onToggleHistory={handleToggleHistory}
+              term={entry?.term || ''}
+              showBack={!showFavorites && fromFavorites}
+              onBack={handleBackFromFavorite}
+              favorited={favorites.includes(entry?.term)}
+              onToggleFavorite={() => entry && toggleFavorite(entry.term)}
+              canFavorite={!!entry && !showFavorites && !showHistory}
+              onOpenSidebar={() => setSidebarOpen(true)}
             />
           </header>
         ) : (

--- a/glancy-site/src/components/MobileTopBar.css
+++ b/glancy-site/src/components/MobileTopBar.css
@@ -6,8 +6,61 @@
   display: flex;
   align-items: center;
 }
-.topbar-text {
+
+.term-text {
   margin-left: 8px;
-  margin-right: auto;
-  font-size: 1.1rem;
+  font-weight: bold;
+}
+
+.back-btn,
+.more-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 8px;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.favorite-toggle {
+  margin-right: 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+}
+
+.more-menu {
+  position: relative;
+}
+
+.more-menu .menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: var(--app-bg);
+  color: var(--app-color);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 4px 0;
+  width: 100px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+}
+
+.more-menu .menu button {
+  background: none;
+  border: none;
+  padding: 4px 8px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.more-menu .menu .icon {
+  margin-right: 4px;
 }

--- a/glancy-site/src/components/MobileTopBar.jsx
+++ b/glancy-site/src/components/MobileTopBar.jsx
@@ -1,24 +1,80 @@
+import { useState, useRef, useEffect } from 'react'
 import { useTheme } from '../ThemeContext.jsx'
 import { useLanguage } from '../LanguageContext.jsx'
 import lightIcon from '../assets/glancy-light.svg'
 import darkIcon from '../assets/glancy-dark.svg'
-import UserMenu from './Header/UserMenu.jsx'
+import ModelSelector from './Toolbar/ModelSelector.jsx'
 import './MobileTopBar.css'
 
-function MobileTopBar({ onToggleFavorites, onToggleHistory }) {
+function MobileTopBar({
+  term = '',
+  showBack = false,
+  onBack,
+  favorited = false,
+  onToggleFavorite,
+  canFavorite = false,
+  onOpenSidebar
+}) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef(null)
   const { resolvedTheme } = useTheme()
   const { lang } = useLanguage()
   const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
-  const text = lang === 'zh' ? '格律词典' : 'Glancy'
+
+  useEffect(() => {
+    function handlePointerDown(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown)
+    }
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [open])
+
   return (
     <>
-      <button className="topbar-btn" onClick={() => window.location.reload()}>
+      <button className="topbar-btn" onClick={onOpenSidebar}>
         <img src={icon} alt="brand" width={24} height={24} />
       </button>
-      <span className="topbar-text">{text}</span>
-      <button className="topbar-btn" onClick={onToggleFavorites}>⭐</button>
-      <button className="topbar-btn" onClick={onToggleHistory}>📜</button>
-      <div className="topbar-btn"><UserMenu size={24} /></div>
+      {showBack && (
+        <button type="button" className="back-btn" onClick={onBack}>
+          ←
+        </button>
+      )}
+      <div className="term-text">{term || (lang === 'zh' ? '格律词典' : 'Glancy')}</div>
+      <div className="topbar-right">
+        {canFavorite && (
+          <button
+            type="button"
+            className="favorite-toggle"
+            onClick={onToggleFavorite}
+          >
+            {favorited ? '★' : '☆'}
+          </button>
+        )}
+        <ModelSelector />
+        <div className="more-menu" ref={menuRef}>
+          <button
+            type="button"
+            className="more-btn"
+            onClick={() => setOpen(!open)}
+          >
+            ⋮
+          </button>
+          {open && (
+            <div className="menu">
+              <button type="button">
+                <span className="icon">🔗</span>Share
+              </button>
+              <button type="button">
+                <span className="icon">🚩</span>Report
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
     </>
   )
 }

--- a/glancy-site/src/components/Sidebar/Sidebar.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.css
@@ -115,11 +115,6 @@ background-color: rgba(255, 255, 255, 0.1);
 border-radius: 4px;
 }
 
-@media (max-width: 600px) {
-  .sidebar-user {
-    display: none;
-  }
-}
 .favorites-list ul {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
### Summary
- revamp mobile top bar with sidebar toggle and desktop-like actions
- slide-out sidebar shows favorites, history and user info
- remove mobile-only user menu rules and add overlay styling

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e61847fa4833290c0746bbe96661c