### PR TITLE
[fix] adjust DictionaryEntry layout

### DIFF
--- a/glancy-site/src/components/DictionaryEntry.css
+++ b/glancy-site/src/components/DictionaryEntry.css
@@ -1,8 +1,6 @@
 .dictionaryEntry {
-  max-width: 600px;
-  margin: 0 auto;
+  width: 100%;
   padding: 20px;
-  border-bottom: 1px solid #eee;
   text-align: left; /* override container centering */
   font-size: 1rem;
   font-weight: normal;
@@ -14,22 +12,8 @@
   font-size: 1em;
   font-weight: bold;
 }
-.termSection .sectionTitle {
-  margin-top: 0;
-}
 .phoneticSection .sectionTitle {
   margin: 8px 0 4px;
-}
-
-.termSection,
-.phoneticSection {
-  text-align: center;
-}
-
-.term {
-  font-size: 1.8em;
-  font-weight: bold;
-  margin: 0;
 }
 
 .phonetic {

--- a/glancy-site/src/components/DictionaryEntry.jsx
+++ b/glancy-site/src/components/DictionaryEntry.jsx
@@ -4,7 +4,7 @@ import './DictionaryEntry.css'
 function DictionaryEntry({ entry }) {
   const { t } = useLanguage()
   if (!entry) return null
-  const { term, phonetic, language, definitions, example } = entry
+  const { phonetic, language, definitions, example } = entry
 
   const languageMap = {
     CHINESE: '中文',
@@ -15,10 +15,6 @@ function DictionaryEntry({ entry }) {
 
   return (
     <article className="dictionaryEntry">
-      <section className="termSection" aria-labelledby="term-title">
-        <h2 id="term-title" className="sectionTitle">【{t.termLabel}】</h2>
-        <p className="term">{term}</p>
-      </section>
       {phonetic && (
         <section className="phoneticSection" aria-labelledby="phon-title">
           <h2 id="phon-title" className="sectionTitle">【{t.phoneticLabel}】</h2>


### PR DESCRIPTION
### Summary
- expand DictionaryEntry width to fill the display area
- remove unused term section and bottom border

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e64e6d24083328c554cebe0db5d79