### PR TITLE
[fix] preserve search history after logout

### DIFF
--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -102,7 +102,8 @@ function UserMenu({ size = 24, showName = false }) {
                   <button
                     type="button"
                     onClick={() => {
-                      clearHistory(user)
+                      // keep search history on the server when logging out
+                      clearHistory()
                       clearUser()
                       setOpen(false)
                     }}


### PR DESCRIPTION
### Summary
- keep search records on logout so history loads again after login

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e7267407c83329fa3377f707f1774