### PR TITLE
[feature] refine user menu layout

### DIFF
--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -30,6 +30,20 @@
   width: 24px;
   height: auto;
 }
+.user-menu .info {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: 1;
+}
+.user-menu .info .username {
+  margin-left: 0;
+}
+.user-menu .info .pro-tag {
+  position: static;
+  transform: none;
+  margin-top: 2px;
+}
 .user-menu .menu {
   position: absolute;
   right: 0;

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -55,8 +55,14 @@ function UserMenu({ size = 24, showName = false }) {
         <>
           <button onClick={() => setOpen(!open)} className={showName ? 'with-name' : ''}>
             <Avatar width={size} height={size} />
-            {isPro && <ProTag />}
-            {showName && <span className="username">{username}</span>}
+            {showName ? (
+              <div className="info">
+                <span className="username">{username}</span>
+                {isPro && <ProTag />}
+              </div>
+            ) : (
+              isPro && <ProTag />
+            )}
           </button>
           {open && (
             <div className="menu">


### PR DESCRIPTION
### Summary
- stack username and pro tag next to avatar when showing name
- add styles for vertical user info area

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e723fff28833280ffe345222a98f6