### PR TITLE
[fix] keep topbar text aligned

### DIFF
--- a/glancy-site/src/components/DesktopTopBar.css
+++ b/glancy-site/src/components/DesktopTopBar.css
@@ -20,6 +20,11 @@
   padding: 0 8px;
 }
 
+.back-btn {
+  width: 32px;
+  text-align: center;
+}
+
 .topbar-right {
   display: flex;
   align-items: center;

--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -29,11 +29,17 @@ function DesktopTopBar({
 
   return (
     <header className="desktop-topbar">
-      {showBack && (
-        <button type="button" className="back-btn" onClick={onBack}>
-          ←
-        </button>
-      )}
+      <button
+        type="button"
+        className="back-btn"
+        onClick={onBack}
+        style={{
+          visibility: showBack ? 'visible' : 'hidden',
+          pointerEvents: showBack ? 'auto' : 'none'
+        }}
+      >
+        ←
+      </button>
       <div className="term-text">{term}</div>
       <div className="topbar-right">
         {canFavorite && (

--- a/glancy-site/src/components/MobileTopBar.css
+++ b/glancy-site/src/components/MobileTopBar.css
@@ -20,6 +20,11 @@
   padding: 0 8px;
 }
 
+.back-btn {
+  width: 32px;
+  text-align: center;
+}
+
 .topbar-right {
   display: flex;
   align-items: center;

--- a/glancy-site/src/components/MobileTopBar.jsx
+++ b/glancy-site/src/components/MobileTopBar.jsx
@@ -38,11 +38,17 @@ function MobileTopBar({
       <button className="topbar-btn" onClick={onOpenSidebar}>
         <img src={icon} alt="brand" width={24} height={24} />
       </button>
-      {showBack && (
-        <button type="button" className="back-btn" onClick={onBack}>
-          ←
-        </button>
-      )}
+      <button
+        type="button"
+        className="back-btn"
+        onClick={onBack}
+        style={{
+          visibility: showBack ? 'visible' : 'hidden',
+          pointerEvents: showBack ? 'auto' : 'none'
+        }}
+      >
+        ←
+      </button>
       <div className="term-text">{term || (lang === 'zh' ? '格律词典' : 'Glancy')}</div>
       <div className="topbar-right">
         {canFavorite && (


### PR DESCRIPTION
### Summary
- reserve space for back button in top bars
- render back button with hidden style when not needed

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e876573108332b677ddcd2609ed9d