### PR TITLE
[fix] top align dictionary entry

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -64,7 +64,8 @@
 .display {
   flex: 1;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: flex-start;
   align-items: center;
   padding: 20px;
   overflow-y: auto;


### PR DESCRIPTION
### Summary
- stop centering the `DictionaryEntry` component

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e882cfb1883329494439fa7fd1cf7