### PR TITLE
[fix] adjust dictionary layout

### DIFF
--- a/glancy-site/src/components/DictionaryEntry.css
+++ b/glancy-site/src/components/DictionaryEntry.css
@@ -1,7 +1,9 @@
 .dictionaryEntry {
-  width: 100%;
-  padding: 20px;
-  text-align: left; /* override container centering */
+  width: auto;
+  margin: 0 2cm;
+  padding: 20px 0;
+  text-align: justify;
+  text-align-last: left;
   font-size: 1rem;
   font-weight: normal;
 }


### PR DESCRIPTION
### Summary
- update dictionary entry margins to keep symmetrical space
- ensure text inside entries aligns and is justified

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687e8a40f688833298a40942778792cc