### PR TITLE
[feature] show login tab for returning users

### DIFF
--- a/glancy-site/src/components/AuthModal.jsx
+++ b/glancy-site/src/components/AuthModal.jsx
@@ -3,10 +3,12 @@ import './AuthModal.css'
 import { useLanguage } from '../LanguageContext.jsx'
 import Login from '../Login.jsx'
 import Register from '../Register.jsx'
+import { useUserStore } from '../store/userStore.js'
 
 function AuthModal({ open, onClose }) {
   const { t } = useLanguage()
-  const [tab, setTab] = useState('register')
+  const currentUser = useUserStore((s) => s.user)
+  const [tab, setTab] = useState(currentUser ? 'login' : 'register')
   if (!open) return null
   return (
     <div className="auth-modal-overlay" onClick={onClose}>


### PR DESCRIPTION
### Summary
- switch initial tab based on previous login info

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687fa540007c8332b0b831b149ac9634