### PR TITLE
[fix] allow profile tooltip overflow

### DIFF
--- a/glancy-site/src/components/ProfileModal.css
+++ b/glancy-site/src/components/ProfileModal.css
@@ -16,5 +16,6 @@
   max-width: 400px;
   width: 90%;
   max-height: 90vh;
-  overflow-y: auto;
+  /* allow tooltip overflow outside the card */
+  overflow: visible;
 }


### PR DESCRIPTION
### Summary
- prevent tooltip clipping inside profile modal

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fbf95ad908332ab3fb92a6ba442d5