### PR TITLE
[feature] cache icons locally

### DIFF
--- a/glancy-site/public/sw.js
+++ b/glancy-site/public/sw.js
@@ -1,0 +1,19 @@
+const CACHE_NAME = 'icon-cache-v1';
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.destination === 'image') {
+    event.respondWith(
+      caches.match(request).then(cached => {
+        if (cached) {
+          return cached;
+        }
+        return fetch(request).then(resp => {
+          const respClone = resp.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, respClone));
+          return resp;
+        });
+      })
+    );
+  }
+});

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -24,3 +24,9 @@ createRoot(document.getElementById('root')).render(
     </LanguageProvider>
   </StrictMode>,
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js')
+  })
+}


### PR DESCRIPTION
### Summary
- cache SVG icons through a service worker
- register the service worker in the main app entry

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_687fc9839a8c83328b08b9acac0cd2b0