### PR TITLE
[fix] adjust user info spacing

### DIFF
--- a/glancy-site/src/components/Header/Header.css
+++ b/glancy-site/src/components/Header/Header.css
@@ -35,6 +35,7 @@
   flex-direction: column;
   align-items: flex-start;
   line-height: 1;
+  gap: 0.25rem;
 }
 .user-menu .info .username {
   margin-left: 0;
@@ -42,7 +43,7 @@
 .user-menu .info .pro-tag {
   position: static;
   transform: none;
-  margin-top: 2px;
+  margin-top: 0;
 }
 .user-menu .menu {
   position: absolute;


### PR DESCRIPTION
### Summary
- add gap to user menu info for vertical spacing
- remove redundant margin from pro badge

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_687fcaba542883328365366fe3c1f7c7