### PR TITLE
[fix] clear UI state on logout

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -170,11 +170,21 @@ function App() {
     }
     document.addEventListener('keydown', handleShortcut)
     return () => document.removeEventListener('keydown', handleShortcut)
-  }, [lang, setLang, theme, setTheme])
+  }, [lang, setLang, theme, setTheme, entry, showFavorites, showHistory, toggleFavorite])
 
   useEffect(() => {
     loadHistory(user)
   }, [user, loadHistory])
+
+  useEffect(() => {
+    if (!user) {
+      setEntry(null)
+      setText('')
+      setShowFavorites(false)
+      setShowHistory(false)
+      setFromFavorites(false)
+    }
+  }, [user])
 
   return (
     <div className="container">

--- a/glancy-site/src/Search.jsx
+++ b/glancy-site/src/Search.jsx
@@ -26,6 +26,13 @@ function Search() {
     loadHistory(user)
   }, [user, loadHistory])
 
+  useEffect(() => {
+    if (!user) {
+      setWord('')
+      setResult(null)
+    }
+  }, [user])
+
   const searchTerm = async (term, updateHistory = true) => {
     setPopupMsg('')
     try {


### PR DESCRIPTION
### Summary
- reset entry and related UI states when the user logs out
- clear search word and result on logout

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fce2aba4483328c2fcb622d6b84bd