### PR TITLE
[fix] remove modal auth

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { useHistoryStore } from './store/historyStore.js'
-import AuthModal from './components/AuthModal.jsx'
 import MessagePopup from './components/MessagePopup.jsx'
 import { useUserStore } from './store/userStore.js'
+import { useNavigate } from 'react-router-dom'
 import { useTheme } from './ThemeContext.jsx'
 import { translations } from './translations.js'
 import DictionaryEntry from './components/DictionaryEntry.jsx'
@@ -28,7 +28,6 @@ function App() {
   const { t, lang, setLang } = useLanguage()
   const placeholder = t.searchPlaceholder
   const [loading, setLoading] = useState(false)
-  const [modalOpen, setModalOpen] = useState(false)
   const [popupOpen, setPopupOpen] = useState(false)
   const [popupMsg, setPopupMsg] = useState('')
   const user = useUserStore((s) => s.user)
@@ -46,6 +45,7 @@ function App() {
   const unfavoriteHistory = useHistoryStore((s) => s.unfavoriteHistory)
   const isMobile = useIsMobile()
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const navigate = useNavigate()
 
   const handleToggleFavorites = () => {
     // always show favorites when invoked
@@ -75,7 +75,7 @@ function App() {
   const handleSend = async (e) => {
     e.preventDefault()
     if (!user) {
-      setModalOpen(true)
+      navigate('/login')
       return
     }
     if (!text.trim()) return
@@ -104,7 +104,7 @@ function App() {
 
   const handleSelectHistory = async (term) => {
     if (!user) {
-      setModalOpen(true)
+      navigate('/login')
       return
     }
     // hide favorites or history display when showing a selected entry
@@ -288,7 +288,6 @@ function App() {
           </a>
         </div>
       </div>
-      <AuthModal open={modalOpen} onClose={() => setModalOpen(false)} />
       <MessagePopup
         open={popupOpen}
         message={popupMsg}

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -5,7 +5,7 @@ import { useLanguage } from '../../LanguageContext.jsx'
 import './Header.css'
 import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
-import AuthModal from '../AuthModal.jsx'
+import { Link } from 'react-router-dom'
 import HelpModal from '../HelpModal.jsx'
 import SettingsModal from '../SettingsModal.jsx'
 import ShortcutsModal from '../ShortcutsModal.jsx'
@@ -16,7 +16,6 @@ import UpgradeModal from '../UpgradeModal.jsx'
 
 function UserMenu({ size = 24, showName = false }) {
   const [open, setOpen] = useState(false)
-  const [modalOpen, setModalOpen] = useState(false)
   const [helpOpen, setHelpOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
@@ -133,16 +132,9 @@ function UserMenu({ size = 24, showName = false }) {
         <div className={showName ? 'with-name' : ''}>
           <Avatar width={size} height={size} />
           {showName && (
-            <>
-              <button
-                type="button"
-                onClick={() => setModalOpen(true)}
-                className="username login-btn"
-              >
-                {t.navRegister}/{t.navLogin}
-              </button>
-              <AuthModal open={modalOpen} onClose={() => setModalOpen(false)} />
-            </>
+            <Link to="/login" className="username login-btn">
+              {t.navRegister}/{t.navLogin}
+            </Link>
           )}
         </div>
       )}

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -1,8 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
+import Login from './Login.jsx'
+import Register from './Register.jsx'
 import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 
@@ -18,7 +20,11 @@ createRoot(document.getElementById('root')).render(
     <LanguageProvider>
       <ThemeProvider>
         <BrowserRouter>
-          <App />
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="*" element={<App />} />
+          </Routes>
         </BrowserRouter>
       </ThemeProvider>
     </LanguageProvider>


### PR DESCRIPTION
### Summary
- switch to route-based login and register pages
- redirect to /login when auth required

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68805b0c65f48332b79c7b736ab7b8aa