### PR TITLE
[feature] add ICP link to auth pages

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -88,3 +88,15 @@
   text-decoration: none;
   margin: 0 4px;
 }
+
+.icp {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 8px 0;
+}
+
+.icp a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -76,6 +76,11 @@ function Login() {
       <div className="footer-links">
         <a href="#">Terms of Use</a> | <a href="#">Privacy Policy</a>
       </div>
+      <div className="icp">
+        <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">
+          京ICP备2025135702号-1
+        </a>
+      </div>
       <MessagePopup
         open={popupOpen}
         message={popupMsg}

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -83,6 +83,11 @@ function Register() {
       <div className="footer-links">
         <a href="#">Terms of Use</a> | <a href="#">Privacy Policy</a>
       </div>
+      <div className="icp">
+        <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">
+          京ICP备2025135702号-1
+        </a>
+      </div>
       <MessagePopup
         open={popupOpen}
         message={popupMsg}


### PR DESCRIPTION
### Summary
- Add ICP record link to login and registration pages
- Style ICP link in auth page CSS similar to main page

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68805eedbef48332ad4c9b57402da4b4