### PR TITLE
[feature] add mobile auth entry

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -75,7 +75,7 @@ function App() {
   const handleSend = async (e) => {
     e.preventDefault()
     if (!user) {
-      navigate('/login')
+      navigate('/auth?tab=login')
       return
     }
     if (!text.trim()) return
@@ -104,7 +104,7 @@ function App() {
 
   const handleSelectHistory = async (term) => {
     if (!user) {
-      navigate('/login')
+      navigate('/auth?tab=login')
       return
     }
     // hide favorites or history display when showing a selected entry

--- a/glancy-site/src/Auth.jsx
+++ b/glancy-site/src/Auth.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { useLanguage } from './LanguageContext.jsx'
+import Login from './Login.jsx'
+import Register from './Register.jsx'
+import { useUserStore } from './store/userStore.js'
+import './components/AuthModal.css'
+
+function Auth() {
+  const { t } = useLanguage()
+  const currentUser = useUserStore((s) => s.user)
+  const [tab, setTab] = useState(currentUser ? 'login' : 'register')
+  return (
+    <div className="auth-modal" style={{ margin: '40px auto' }}>
+      <div className="auth-tabs">
+        <button
+          type="button"
+          onClick={() => setTab('register')}
+          className={tab === 'register' ? 'active' : ''}
+        >
+          {t.navRegister}
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('login')}
+          className={tab === 'login' ? 'active' : ''}
+        >
+          {t.navLogin}
+        </button>
+      </div>
+      {tab === 'register' ? <Register /> : <Login />}
+    </div>
+  )
+}
+
+export default Auth

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -50,7 +50,7 @@ function Login() {
         </button>
       </form>
       <div className="auth-switch">
-        Don’t have an account? <Link to="/register">Sign up</Link>
+        Don’t have an account? <Link to="/auth?tab=register">Sign up</Link>
       </div>
       <div className="divider">
         <span>OR</span>

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -57,7 +57,7 @@ function Register() {
         </button>
       </form>
       <div className="auth-switch">
-        Already have an account? <Link to="/login">Log in</Link>
+        Already have an account? <Link to="/auth?tab=login">Log in</Link>
       </div>
       <div className="divider">
         <span>OR</span>

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -6,6 +6,7 @@ import './Header.css'
 import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
 import { Link } from 'react-router-dom'
+import { useIsMobile } from '../../utils.js'
 import HelpModal from '../HelpModal.jsx'
 import SettingsModal from '../SettingsModal.jsx'
 import ShortcutsModal from '../ShortcutsModal.jsx'
@@ -22,6 +23,7 @@ function UserMenu({ size = 24, showName = false }) {
   const [profileOpen, setProfileOpen] = useState(false)
   const [upgradeOpen, setUpgradeOpen] = useState(false)
   const menuRef = useRef(null)
+  const isMobile = useIsMobile()
   const user = useUserStore((s) => s.user)
   const clearUser = useUserStore((s) => s.clearUser)
   const clearHistory = useHistoryStore((s) => s.clearHistory)
@@ -132,7 +134,10 @@ function UserMenu({ size = 24, showName = false }) {
         <div className={showName ? 'with-name' : ''}>
           <Avatar width={size} height={size} />
           {showName && (
-            <Link to="/login" className="username login-btn">
+            <Link
+              to={isMobile ? '/auth' : '/login'}
+              className="username login-btn"
+            >
               {t.navRegister}/{t.navLogin}
             </Link>
           )}

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -5,6 +5,7 @@ import './index.css'
 import App from './App.jsx'
 import Login from './Login.jsx'
 import Register from './Register.jsx'
+import Auth from './Auth.jsx'
 import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 
@@ -23,6 +24,7 @@ createRoot(document.getElementById('root')).render(
           <Routes>
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
+            <Route path="/auth" element={<Auth />} />
             <Route path="*" element={<App />} />
           </Routes>
         </BrowserRouter>


### PR DESCRIPTION
### Summary
- added `/auth` route combining register and login pages
- mobile login link now opens the new auth page

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6880618d9b688332bf5164c2112ba9e3