### PR TITLE
[fix] adjust auth button text color

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -27,13 +27,27 @@
 .auth-primary-btn {
   width: 100%;
   background: var(--primary-bg);
-  color: var(--primary-color);
+  color: #000;
   border: none;
   border-radius: 24px;
   padding: 12px 16px;
   font-size: 16px;
   cursor: pointer;
   margin-bottom: 16px;
+}
+
+:root[data-theme='dark'] .auth-primary-btn {
+  color: #fff;
+}
+
+:root[data-theme='system'] .auth-primary-btn {
+  color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme='system'] .auth-primary-btn {
+    color: #fff;
+  }
 }
 .auth-switch {
   color: #666;


### PR DESCRIPTION
### Summary
- set login and register button text color to system black
- add dark mode overrides for white text

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880627d8bec8332826fb80c8d7df311