### PR TITLE
[feature] add login icon

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -5,6 +5,11 @@
   font-family: system-ui, Arial, sans-serif;
   text-align: center;
 }
+.auth-logo {
+  width: 48px;
+  height: 48px;
+  margin: 0 auto 8px;
+}
 .auth-brand {
   font-weight: 600;
   font-size: 24px;

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -9,6 +9,9 @@ import googleIcon from './assets/google.svg'
 import appleIcon from './assets/apple.svg'
 import phoneIcon from './assets/phone.svg'
 import wechatIcon from './assets/wechat.svg'
+import lightIcon from './assets/glancy-light.svg'
+import darkIcon from './assets/glancy-dark.svg'
+import { useTheme } from './ThemeContext.jsx'
 
 function Login() {
   const setUser = useUserStore((s) => s.setUser)
@@ -16,6 +19,8 @@ function Login() {
   const [popupOpen, setPopupOpen] = useState(false)
   const [popupMsg, setPopupMsg] = useState('')
   const navigate = useNavigate()
+  const { resolvedTheme } = useTheme()
+  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -36,6 +41,7 @@ function Login() {
 
   return (
     <div className="auth-page">
+      <img className="auth-logo" src={icon} alt="Glancy" />
       <div className="auth-brand">Glancy</div>
       <h1 className="auth-title">Welcome back</h1>
       <form onSubmit={handleSubmit}>

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -9,6 +9,9 @@ import googleIcon from './assets/google.svg'
 import appleIcon from './assets/apple.svg'
 import phoneIcon from './assets/phone.svg'
 import wechatIcon from './assets/wechat.svg'
+import lightIcon from './assets/glancy-light.svg'
+import darkIcon from './assets/glancy-dark.svg'
+import { useTheme } from './ThemeContext.jsx'
 
 function Register() {
   const [email, setEmail] = useState('')
@@ -16,6 +19,8 @@ function Register() {
   const [popupMsg, setPopupMsg] = useState('')
   const navigate = useNavigate()
   const setUser = useUserStore((s) => s.setUser)
+  const { resolvedTheme } = useTheme()
+  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -43,6 +48,7 @@ function Register() {
 
   return (
     <div className="auth-page">
+      <img className="auth-logo" src={icon} alt="Glancy" />
       <div className="auth-brand">Glancy</div>
       <h1 className="auth-title">Create an account</h1>
       <form onSubmit={handleSubmit}>


### PR DESCRIPTION
### Summary
- display app logo above brand on login and register pages

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68806587e7d48332968a9a76337bca0b