### PR TITLE
[fix] adjust mobile topbar spacing

### DIFF
--- a/glancy-site/src/components/MobileTopBar.css
+++ b/glancy-site/src/components/MobileTopBar.css
@@ -1,14 +1,14 @@
 .topbar-btn {
   background: none;
   border: none;
-  padding: 0 8px;
+  padding: 0 4px;
   cursor: pointer;
   display: flex;
   align-items: center;
 }
 
 .term-text {
-  margin-left: 8px;
+  margin-left: 4px;
   font-weight: bold;
 }
 


### PR DESCRIPTION
### Summary
- reduce padding for mobile topbar icon
- reduce margin before brand text

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68807141bae483328a06011370335d37