### PR TITLE
[fix] improve auth dark mode

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -17,18 +17,20 @@
 .auth-brand {
   font-weight: 600;
   font-size: 24px;
-  color: #000;
+  color: var(--app-color);
   margin-bottom: 8px;
 }
 .auth-title {
   font-size: 24px;
-  color: #000;
+  color: var(--app-color);
   margin-bottom: 32px;
 }
 .auth-input {
   width: 100%;
   padding: 12px 16px;
-  border: 1px solid #5d5fef;
+  border: 1px solid var(--border-color);
+  background: var(--input-bg);
+  color: var(--app-color);
   border-radius: 24px;
   font-size: 16px;
   margin-bottom: 16px;
@@ -36,7 +38,7 @@
 .auth-primary-btn {
   width: 100%;
   background: var(--primary-bg);
-  color: #000;
+  color: var(--primary-color);
   border: none;
   border-radius: 24px;
   padding: 12px 16px;
@@ -46,20 +48,20 @@
 }
 
 :root[data-theme='dark'] .auth-primary-btn {
-  color: #fff;
+  color: var(--primary-color);
 }
 
 :root[data-theme='system'] .auth-primary-btn {
-  color: #000;
+  color: var(--primary-color);
 }
 
 @media (prefers-color-scheme: dark) {
   :root[data-theme='system'] .auth-primary-btn {
-    color: #fff;
+    color: var(--primary-color);
   }
 }
 .auth-switch {
-  color: #666;
+  color: var(--text-muted);
   font-size: 14px;
   margin-bottom: 24px;
 }
@@ -77,11 +79,11 @@
   content: '';
   flex: 1;
   height: 1px;
-  background: #ddd;
+  background: var(--border-color);
 }
 .divider span {
   margin: 0 8px;
-  color: #999;
+  color: var(--text-muted);
   font-size: 12px;
 }
 .oauth-buttons button {
@@ -91,8 +93,8 @@
   justify-content: flex-start;
   text-align: left;
   width: 100%;
-  background: #fff;
-  border: 1px solid #e0e0e0;
+  background: var(--input-bg);
+  border: 1px solid var(--border-color);
   border-radius: 24px;
   padding: 12px 16px;
   margin-bottom: 12px;
@@ -105,7 +107,7 @@
 .footer-links {
   margin-top: 24px;
   font-size: 12px;
-  color: #999;
+  color: var(--text-muted);
 }
 .footer-links a {
   color: #5d5fef;


### PR DESCRIPTION
### Summary
- adapt colors on login/register pages using theme variables

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6880c81aeeac833298136abc1af8a892