### PR TITLE
[feature] theme icons for auth pages

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -105,6 +105,20 @@
   height: 24px;
 }
 
+:root[data-theme='dark'] .oauth-buttons img {
+  filter: invert(1);
+}
+
+:root[data-theme='system'] .oauth-buttons img {
+  filter: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme='system'] .oauth-buttons img {
+    filter: invert(1);
+  }
+}
+
 .login-options {
   display: flex;
   gap: 12px;
@@ -125,6 +139,20 @@
 .login-options img {
   width: 24px;
   height: 24px;
+}
+
+:root[data-theme='dark'] .login-options img {
+  filter: invert(1);
+}
+
+:root[data-theme='system'] .login-options img {
+  filter: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root[data-theme='system'] .login-options img {
+    filter: invert(1);
+  }
 }
 .footer-links {
   margin-top: 24px;


### PR DESCRIPTION
### Summary
- adapt login option icons to dark and light themes

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880cc34b7c08332b88fa44bb4c1ff95