### PR TITLE
[fix] adjust login form spacing

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -158,6 +158,7 @@
   width: 100%;
   max-width: 360px;
   gap: 8px;
+  margin-bottom: 16px;
 }
 
 .password-row .auth-input {


### PR DESCRIPTION
### Summary
- add bottom margin to the password row so the button spacing matches inputs

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880ddc633d88332bb90ef79e2ad0fc6