### PR TITLE
[feature] add close icon on auth pages

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 }
 .auth-logo {
   width: 48px;
@@ -214,4 +215,13 @@
 .icp a {
   color: inherit;
   text-decoration: none;
+}
+
+.auth-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  text-decoration: none;
+  color: var(--text-muted);
+  font-size: 24px;
 }

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -101,6 +101,7 @@ function Login() {
 
   return (
     <div className="auth-page">
+      <Link to="/" className="auth-close">×</Link>
       <img className="auth-logo" src={icon} alt="Glancy" />
       <div className="auth-brand">Glancy</div>
       <h1 className="auth-title">Welcome back</h1>

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -48,6 +48,7 @@ function Register() {
 
   return (
     <div className="auth-page">
+      <Link to="/" className="auth-close">×</Link>
       <img className="auth-logo" src={icon} alt="Glancy" />
       <div className="auth-brand">Glancy</div>
       <h1 className="auth-title">Create an account</h1>


### PR DESCRIPTION
### Summary
- add close button to login and register pages
- allow auth pages to be positioned relatively

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880dea465d08332b27b72a48c2cf139