### PR TITLE
[feature] add code button countdown

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -177,6 +177,11 @@
   cursor: pointer;
 }
 
+.code-btn[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 :root[data-theme='dark'] .login-options img {
   filter: invert(1);
 }

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import CodeButton from './components/CodeButton.jsx'
 import { useNavigate, Link } from 'react-router-dom'
 import './AuthPage.css'
 import { API_PATHS } from './config/api.js'
@@ -75,13 +76,7 @@ function Login() {
             onChange={(e) => setPassword(e.target.value)}
           />
           {method !== 'username' && (
-            <button
-              type="button"
-              className="code-btn"
-              onClick={handleSendCode}
-            >
-              Get code
-            </button>
+            <CodeButton onClick={handleSendCode} />
           )}
         </div>
         <button type="submit" className="auth-primary-btn">Continue</button>

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import CodeButton from './components/CodeButton.jsx'
 import { useNavigate, Link } from 'react-router-dom'
 import './AuthPage.css'
 import { API_PATHS } from './config/api.js'
@@ -108,13 +109,7 @@ function Register() {
             value={account}
             onChange={(e) => setAccount(e.target.value)}
           />
-          <button
-            type="button"
-            className="code-btn"
-            onClick={handleSendCode}
-          >
-            Get code
-          </button>
+          <CodeButton onClick={handleSendCode} />
         </div>
         <input
           className="auth-input"

--- a/glancy-site/src/components/CodeButton.jsx
+++ b/glancy-site/src/components/CodeButton.jsx
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react'
+
+// button with 60s countdown after click
+
+function CodeButton({ onClick }) {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (count === 0) return undefined
+    const id = setInterval(() => {
+      setCount((c) => c - 1)
+    }, 1000)
+    return () => clearInterval(id)
+  }, [count])
+
+  const handleClick = () => {
+    if (onClick) onClick()
+    setCount(60)
+  }
+
+  return (
+    <button
+      type="button"
+      className="code-btn"
+      disabled={count > 0}
+      onClick={handleClick}
+    >
+      {count > 0 ? `${count}s` : 'Get code'}
+    </button>
+  )
+}
+
+export default CodeButton


### PR DESCRIPTION
### Summary
- add CodeButton component with 60s countdown
- replace verification buttons in login and register pages

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6880ed34e204833296df17ee84886fc2