### PR TITLE
[fix] keep width of code button

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -174,6 +174,7 @@
   color: var(--app-color);
   border-radius: 24px;
   font-size: 14px;
+  width: 96px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
### Summary
- prevent width change on verification code button

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880f10d6120833287e533053683ff0a