### PR TITLE
[fix] unify highlight color

### DIFF
--- a/glancy-site/src/AuthPage.css
+++ b/glancy-site/src/AuthPage.css
@@ -75,7 +75,7 @@
   margin-bottom: 24px;
 }
 .auth-switch a {
-  color: #5d5fef;
+  color: var(--highlight-color);
   text-decoration: none;
 }
 .divider {
@@ -207,7 +207,7 @@
   margin-bottom: 4px;
 }
 .footer-links a {
-  color: #5d5fef;
+  color: var(--highlight-color);
   text-decoration: none;
   margin: 0 4px;
 }

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -8,6 +8,7 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   --vh: 100vh;
+  --highlight-color: #fff;
 }
 
 @supports (height: 100dvh) {
@@ -110,15 +111,15 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--highlight-color);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--highlight-color);
 }
 
 :root[data-theme='light'] a:hover {
-  color: #747bff;
+  color: var(--highlight-color);
 }
 
 body {
@@ -148,7 +149,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--highlight-color);
 }
 button:focus,
 button:focus-visible {


### PR DESCRIPTION
### Summary
- add `--highlight-color` variable and set to white
- use highlight color for links and buttons

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_688105ec61208332aaa3855489d839b2