### PR TITLE
[fix] adjust highlight color for light theme

### DIFF
--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -27,6 +27,7 @@
   color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
+  --highlight-color: #fff;
   --app-bg: #2c2c2c;
   --app-color: rgba(255, 255, 255, 0.87);
   --chat-window-bg: #333;
@@ -48,6 +49,7 @@
   color-scheme: light;
   color: #213547;
   background-color: #ffffff;
+  --highlight-color: #000;
   --app-bg: #f5f5f5;
   --app-color: #333;
   --chat-window-bg: #fafafa;
@@ -73,6 +75,7 @@
   :root[data-theme='system'] {
     color: rgba(255, 255, 255, 0.87);
     background-color: #242424;
+    --highlight-color: #fff;
     --app-bg: #2c2c2c;
     --app-color: rgba(255, 255, 255, 0.87);
     --chat-window-bg: #333;
@@ -93,6 +96,7 @@
   :root[data-theme='system'] {
     color: #213547;
     background-color: #ffffff;
+    --highlight-color: #000;
     --app-bg: #f5f5f5;
     --app-color: #333;
     --chat-window-bg: #fafafa;


### PR DESCRIPTION
### Summary
- adapt highlight font color to theme

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6881160cf05083329cea5edc114257e1