### PR TITLE
[fix] adjust auth button colors

### DIFF
--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -69,6 +69,8 @@
 
 :root[data-theme='system'] {
   color-scheme: light dark;
+  --primary-bg: Canvas;
+  --primary-color: CanvasText;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
### Summary
- use Canvas and CanvasText for system theme auth buttons

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6881c1f2273083328d6ae893357a533d