### PR TITLE
[fix] show logout confirmation

### DIFF
--- a/glancy-site/src/components/LogoutConfirmModal.jsx
+++ b/glancy-site/src/components/LogoutConfirmModal.jsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import './LogoutConfirmModal.css'
 import { useLanguage } from '../LanguageContext.jsx'
 
@@ -5,8 +6,8 @@ function LogoutConfirmModal({ open, onConfirm, onCancel, email }) {
   const { t } = useLanguage()
   if (!open) return null
   const message = t.logoutConfirmMessage.replace('{email}', email)
-  return (
-    <div className="logout-overlay">
+  return createPortal(
+    <div className="logout-overlay" onClick={onCancel}>
       <div className="logout-modal" onClick={(e) => e.stopPropagation()}>
         <h3>{t.logoutConfirmTitle}</h3>
         <p className="message">{message}</p>
@@ -19,7 +20,8 @@ function LogoutConfirmModal({ open, onConfirm, onCancel, email }) {
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   )
 }
 


### PR DESCRIPTION
### Summary
- render logout modal via portal so the popup shows correctly

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6881c32d7d4083329be0634e4962ac88