### PR TITLE
[refactor] centralize color tokens

### DIFF
--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -1,3 +1,5 @@
+@import './theme/colors.css';
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
@@ -8,7 +10,7 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   --vh: 100vh;
-  --highlight-color: #000;
+  --highlight-color: var(--hl-dark);
 }
 
 @supports (height: 100dvh) {
@@ -25,9 +27,9 @@
 
 :root[data-theme='dark'] {
   color-scheme: dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-  --highlight-color: #000;
+  color: var(--sys-text-dark);
+  background-color: var(--sys-bg-dark);
+  --highlight-color: var(--hl-dark);
   --app-bg: #2c2c2c;
   --app-color: rgba(255, 255, 255, 0.87);
   --chat-window-bg: #333;
@@ -38,18 +40,18 @@
   --sidebar-color: #fff;
   --input-bg: #2c2c2c;
   --accent-color: #facc15;
-  --border-color: #333;
-  --text-muted: #aaa;
-  --brand-color: orange;
+  --border-color: var(--sys-border-dark);
+  --text-muted: var(--sys-muted);
+  --brand-color: var(--brand-color);
   --primary-bg: #f2f2f2;
   --primary-color: #121212;
 }
 
 :root[data-theme='light'] {
   color-scheme: light;
-  color: #213547;
-  background-color: #ffffff;
-  --highlight-color: #fff;
+  color: var(--sys-text-light);
+  background-color: var(--sys-bg-light);
+  --highlight-color: var(--hl-light);
   --app-bg: #f5f5f5;
   --app-color: #333;
   --chat-window-bg: #fafafa;
@@ -60,9 +62,9 @@
   --sidebar-color: #333;
   --input-bg: #ffffff;
   --accent-color: #facc15;
-  --border-color: #ccc;
-  --text-muted: #aaa;
-  --brand-color: orange;
+  --border-color: var(--sys-border-light);
+  --text-muted: var(--sys-muted);
+  --brand-color: var(--brand-color);
   --primary-bg: #121212;
   --primary-color: #f2f2f2;
 }
@@ -75,9 +77,9 @@
 
 @media (prefers-color-scheme: dark) {
   :root[data-theme='system'] {
-    color: rgba(255, 255, 255, 0.87);
-    background-color: #242424;
-    --highlight-color: #000;
+    color: var(--sys-text-dark);
+    background-color: var(--sys-bg-dark);
+    --highlight-color: var(--hl-dark);
     --app-bg: #2c2c2c;
     --app-color: rgba(255, 255, 255, 0.87);
     --chat-window-bg: #333;
@@ -88,17 +90,17 @@
     --sidebar-color: #fff;
     --input-bg: #2c2c2c;
     --accent-color: #facc15;
-    --border-color: #333;
-    --text-muted: #aaa;
-    --brand-color: orange;
+    --border-color: var(--sys-border-dark);
+    --text-muted: var(--sys-muted);
+    --brand-color: var(--brand-color);
   }
 }
 
 @media (prefers-color-scheme: light) {
   :root[data-theme='system'] {
-    color: #213547;
-    background-color: #ffffff;
-    --highlight-color: #fff;
+    color: var(--sys-text-light);
+    background-color: var(--sys-bg-light);
+    --highlight-color: var(--hl-light);
     --app-bg: #f5f5f5;
     --app-color: #333;
     --chat-window-bg: #fafafa;
@@ -109,9 +111,9 @@
     --sidebar-color: #333;
     --input-bg: #ffffff;
     --accent-color: #facc15;
-    --border-color: #ccc;
-    --text-muted: #aaa;
-    --brand-color: orange;
+    --border-color: var(--sys-border-light);
+    --text-muted: var(--sys-muted);
+    --brand-color: var(--brand-color);
   }
 }
 

--- a/glancy-site/src/theme/colors.css
+++ b/glancy-site/src/theme/colors.css
@@ -1,0 +1,19 @@
+/* central color tokens */
+:root {
+  /* highlight colors */
+  --hl-light: #ffffff;
+  --hl-dark: #000000;
+
+  /* system colors */
+  --sys-text-light: #213547;
+  --sys-text-dark: rgba(255, 255, 255, 0.87);
+  --sys-bg-light: #ffffff;
+  --sys-bg-dark: #242424;
+
+  --sys-border-light: #ccc;
+  --sys-border-dark: #333;
+  --sys-muted: #aaa;
+
+  --accent-color: #facc15;
+  --brand-color: orange;
+}


### PR DESCRIPTION
### Summary
- add shared color token file with highlight/system categories
- switch theme styles to reference the new tokens

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6881cbcde89c8332aed92fedbd43f279