### PR TITLE
[refactor] modularize topbar actions

### DIFF
--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -1,10 +1,6 @@
-import { useState, useRef, useEffect } from 'react'
-import ModelSelector from './Toolbar/ModelSelector.jsx'
 import './DesktopTopBar.css'
 import './Header/Header.css'
-import { useLanguage } from '../LanguageContext.jsx'
-import { useUserStore } from '../store/userStore.js'
-import { Link } from 'react-router-dom'
+import TopBarActions from './TopBarActions.jsx'
 
 function DesktopTopBar({
   term = '',
@@ -14,22 +10,6 @@ function DesktopTopBar({
   onToggleFavorite,
   canFavorite = false
 }) {
-  const [open, setOpen] = useState(false)
-  const menuRef = useRef(null)
-  const { t } = useLanguage()
-  const user = useUserStore((s) => s.user)
-
-  useEffect(() => {
-    function handlePointerDown(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setOpen(false)
-      }
-    }
-    if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
 
   return (
     <header className="desktop-topbar">
@@ -45,41 +25,11 @@ function DesktopTopBar({
         ←
       </button>
       <div className="term-text">{term}</div>
-      <div className="topbar-right">
-        {canFavorite && (
-          <button
-            type="button"
-            className="favorite-toggle"
-            onClick={onToggleFavorite}
-          >
-            {favorited ? '★' : '☆'}
-          </button>
-        )}
-        {user ? (
-          <>
-            <ModelSelector />
-            <div className="more-menu" ref={menuRef}>
-              <button
-                type="button"
-                className="more-btn"
-                onClick={() => setOpen(!open)}
-              >
-                ⋮
-              </button>
-              {open && (
-                <div className="menu">
-                  <button type="button">
-                    <span className="icon">🔗</span>{t.share}
-                  </button>
-                  <button type="button">
-                    <span className="icon">🚩</span>{t.report}
-                  </button>
-                </div>
-              )}
-            </div>
-          </>
-        ) : null}
-      </div>
+      <TopBarActions
+        favorited={favorited}
+        onToggleFavorite={onToggleFavorite}
+        canFavorite={canFavorite}
+      />
     </header>
   )
 }

--- a/glancy-site/src/components/MobileTopBar.jsx
+++ b/glancy-site/src/components/MobileTopBar.jsx
@@ -1,11 +1,8 @@
-import { useState, useRef, useEffect } from 'react'
 import { useTheme } from '../ThemeContext.jsx'
 import { useLanguage } from '../LanguageContext.jsx'
 import lightIcon from '../assets/glancy-web-light.svg'
 import darkIcon from '../assets/glancy-web-dark.svg'
-import ModelSelector from './Toolbar/ModelSelector.jsx'
-import { Link } from 'react-router-dom'
-import { useUserStore } from '../store/userStore.js'
+import TopBarActions from './TopBarActions.jsx'
 import './MobileTopBar.css'
 
 function MobileTopBar({
@@ -17,24 +14,9 @@ function MobileTopBar({
   canFavorite = false,
   onOpenSidebar
 }) {
-  const [open, setOpen] = useState(false)
-  const menuRef = useRef(null)
   const { resolvedTheme } = useTheme()
-  const { lang, t } = useLanguage()
+  const { lang } = useLanguage()
   const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
-  const user = useUserStore((s) => s.user)
-
-  useEffect(() => {
-    function handlePointerDown(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setOpen(false)
-      }
-    }
-    if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
 
   return (
     <>
@@ -53,41 +35,11 @@ function MobileTopBar({
         ←
       </button>
       <div className="term-text">{term || (lang === 'zh' ? '格律词典' : 'Glancy')}</div>
-      <div className="topbar-right">
-        {canFavorite && (
-          <button
-            type="button"
-            className="favorite-toggle"
-            onClick={onToggleFavorite}
-          >
-            {favorited ? '★' : '☆'}
-          </button>
-        )}
-        {user ? (
-          <>
-            <ModelSelector />
-            <div className="more-menu" ref={menuRef}>
-              <button
-                type="button"
-                className="more-btn"
-                onClick={() => setOpen(!open)}
-              >
-                ⋮
-              </button>
-              {open && (
-                <div className="menu">
-                  <button type="button">
-                    <span className="icon">🔗</span>{t.share}
-                  </button>
-                  <button type="button">
-                    <span className="icon">🚩</span>{t.report}
-                  </button>
-                </div>
-              )}
-            </div>
-          </>
-        ) : null}
-      </div>
+      <TopBarActions
+        favorited={favorited}
+        onToggleFavorite={onToggleFavorite}
+        canFavorite={canFavorite}
+      />
     </>
   )
 }

--- a/glancy-site/src/components/TopBarActions.jsx
+++ b/glancy-site/src/components/TopBarActions.jsx
@@ -1,0 +1,55 @@
+import { useState, useRef, useEffect } from 'react'
+import ModelSelector from './Toolbar/ModelSelector.jsx'
+import { useLanguage } from '../LanguageContext.jsx'
+import { useUserStore } from '../store/userStore.js'
+
+function TopBarActions({ favorited = false, onToggleFavorite, canFavorite = false }) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef(null)
+  const { t } = useLanguage()
+  const user = useUserStore((s) => s.user)
+
+  useEffect(() => {
+    function handlePointerDown(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown)
+    }
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [open])
+
+  if (!user) return null
+
+  return (
+    <div className="topbar-right">
+      {canFavorite && (
+        <button type="button" className="favorite-toggle" onClick={onToggleFavorite}>
+          {favorited ? '★' : '☆'}
+        </button>
+      )}
+      <ModelSelector />
+      <div className="more-menu" ref={menuRef}>
+        <button type="button" className="more-btn" onClick={() => setOpen(!open)}>
+          ⋮
+        </button>
+        {open && (
+          <div className="menu">
+            <button type="button">
+              <span className="icon">🔗</span>
+              {t.share}
+            </button>
+            <button type="button">
+              <span className="icon">🚩</span>
+              {t.report}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default TopBarActions


### PR DESCRIPTION
### Summary
- extract a reusable `TopBarActions` component
- simplify `DesktopTopBar` and `MobileTopBar` by using the new component

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_688251c23a048332b048643dfb1573ff