### PR TITLE
[refactor] remove portal usage

### DIFF
--- a/glancy-site/src/components/LogoutConfirmModal.jsx
+++ b/glancy-site/src/components/LogoutConfirmModal.jsx
@@ -1,4 +1,3 @@
-import { createPortal } from 'react-dom'
 import './LogoutConfirmModal.css'
 import { useLanguage } from '../LanguageContext.jsx'
 
@@ -6,7 +5,7 @@ function LogoutConfirmModal({ open, onConfirm, onCancel, email }) {
   const { t } = useLanguage()
   if (!open) return null
   const message = t.logoutConfirmMessage.replace('{email}', email)
-  return createPortal(
+  return (
     <div className="logout-overlay" onClick={onCancel}>
       <div className="logout-modal" onClick={(e) => e.stopPropagation()}>
         <h3>{t.logoutConfirmTitle}</h3>
@@ -20,8 +19,7 @@ function LogoutConfirmModal({ open, onConfirm, onCancel, email }) {
           </button>
         </div>
       </div>
-    </div>,
-    document.body
+    </div>
   )
 }
 


### PR DESCRIPTION
### Summary
- remove portal-based rendering from `LogoutConfirmModal`

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688266c202c08332824255709ea12845