### PR TITLE
[feature] add locale helper and context

### DIFF
--- a/glancy-site/src/LanguageContext.jsx
+++ b/glancy-site/src/LanguageContext.jsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { translations } from './translations.js'
-import { API_PATHS } from './config/api.js'
-import { apiRequest } from './api/client.js'
+import { useLocale } from './LocaleContext.jsx'
 
 const LanguageContext = createContext({
   lang: 'zh',
@@ -13,19 +12,16 @@ export function LanguageProvider({ children }) {
   const [lang, setLang] = useState(() => localStorage.getItem('lang') || 'zh')
   const [t, setT] = useState(() => translations[localStorage.getItem('lang')] || translations.zh)
 
+  const { locale } = useLocale()
+
   useEffect(() => {
-    const stored = localStorage.getItem('lang')
-    if (stored) return
-    apiRequest(API_PATHS.locale)
-      .then((data) => {
-        if (translations[data.lang]) {
-          setLang(data.lang)
-          setT(translations[data.lang])
-          localStorage.setItem('lang', data.lang)
-        }
-      })
-      .catch(() => {})
-  }, [])
+    if (localStorage.getItem('lang') || !locale) return
+    if (translations[locale.lang]) {
+      setLang(locale.lang)
+      setT(translations[locale.lang])
+      localStorage.setItem('lang', locale.lang)
+    }
+  }, [locale])
 
   useEffect(() => {
     document.title = t.welcomeTitle

--- a/glancy-site/src/LocaleContext.jsx
+++ b/glancy-site/src/LocaleContext.jsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { getLocale } from './api/locale.js'
+
+const LocaleContext = createContext({
+  locale: null,
+  setLocale: () => {}
+})
+
+export function LocaleProvider({ children }) {
+  const [locale, setLocale] = useState(() => {
+    const stored = localStorage.getItem('locale')
+    return stored ? JSON.parse(stored) : null
+  })
+
+  useEffect(() => {
+    if (locale) return
+    getLocale()
+      .then((data) => {
+        setLocale(data)
+        localStorage.setItem('locale', JSON.stringify(data))
+      })
+      .catch(() => {})
+  }, [locale])
+
+  return (
+    <LocaleContext.Provider value={{ locale, setLocale }}>
+      {children}
+    </LocaleContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useLocale = () => useContext(LocaleContext)

--- a/glancy-site/src/api/locale.js
+++ b/glancy-site/src/api/locale.js
@@ -1,0 +1,4 @@
+import { API_PATHS } from '../config/api.js'
+import { apiRequest } from './client.js'
+
+export const getLocale = () => apiRequest(API_PATHS.locale)

--- a/glancy-site/src/components/PhoneInput.jsx
+++ b/glancy-site/src/components/PhoneInput.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
-import { API_PATHS } from '../config/api.js'
-import { apiRequest } from '../api/client.js'
+import { getLocale } from '../api/locale.js'
+import { useLocale } from '../LocaleContext.jsx'
 import '../AuthPage.css'
 
 const CODE_LIST = [
@@ -21,15 +21,22 @@ function PhoneInput({ onChange, placeholder = 'Phone number' }) {
   const [number, setNumber] = useState('')
   const [open, setOpen] = useState(false)
   const ref = useRef(null)
+  const { locale, setLocale } = useLocale()
 
   useEffect(() => {
-    apiRequest(API_PATHS.locale)
+    if (locale) {
+      const found = CODE_LIST.find((c) => c.country === locale.country)
+      if (found) setCode(found.code)
+      return
+    }
+    getLocale()
       .then((data) => {
+        setLocale(data)
         const found = CODE_LIST.find((c) => c.country === data.country)
         if (found) setCode(found.code)
       })
       .catch(() => {})
-  }, [])
+  }, [locale, setLocale])
 
   useEffect(() => {
     const handler = (e) => {

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -7,6 +7,7 @@ import Login from './Login.jsx'
 import Register from './Register.jsx'
 import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
+import { LocaleProvider } from './LocaleContext.jsx'
 
 function updateVh() {
   document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`)
@@ -17,17 +18,19 @@ window.addEventListener('resize', updateVh)
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <LanguageProvider>
-      <ThemeProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/register" element={<Register />} />
-            <Route path="*" element={<App />} />
-          </Routes>
-        </BrowserRouter>
-      </ThemeProvider>
-    </LanguageProvider>
+    <LocaleProvider>
+      <LanguageProvider>
+        <ThemeProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<Login />} />
+              <Route path="/register" element={<Register />} />
+              <Route path="*" element={<App />} />
+            </Routes>
+          </BrowserRouter>
+        </ThemeProvider>
+      </LanguageProvider>
+    </LocaleProvider>
   </StrictMode>,
 )
 


### PR DESCRIPTION
### Summary
- unify locale fetching via `getLocale`
- cache locale in `LocaleProvider`
- use cached locale in language and phone input components

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68826e6bdfcc83329e214eecca15d5b1