### PR TITLE
[feature] reorganize user menu

### DIFF
--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,29 +1,14 @@
-import { useRef, useState, useEffect } from 'react'
 import { useUserStore } from '../../store/userStore.js'
 import { useHistoryStore } from '../../store/historyStore.js'
 import { useLanguage } from '../../LanguageContext.jsx'
 import './Header.css'
-import ProTag from './ProTag.jsx'
 import Avatar from '../Avatar.jsx'
 import { Link } from 'react-router-dom'
-import HelpModal from '../HelpModal.jsx'
-import SettingsModal from '../SettingsModal.jsx'
-import ShortcutsModal from '../ShortcutsModal.jsx'
-import ProfileModal from '../ProfileModal.jsx'
-import UpgradeModal from '../UpgradeModal.jsx'
-import LogoutConfirmModal from '../LogoutConfirmModal.jsx'
-
-// size 控制触发按钮中头像的尺寸
+import UserMenuButton from './UserMenuButton.jsx'
+import UserMenuDropdown from './UserMenuDropdown.jsx'
+import UserMenuModals from './UserMenuModals.jsx'
 
 function UserMenu({ size = 24, showName = false }) {
-  const [open, setOpen] = useState(false)
-  const [helpOpen, setHelpOpen] = useState(false)
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [shortcutsOpen, setShortcutsOpen] = useState(false)
-  const [profileOpen, setProfileOpen] = useState(false)
-  const [upgradeOpen, setUpgradeOpen] = useState(false)
-  const [logoutOpen, setLogoutOpen] = useState(false)
-  const menuRef = useRef(null)
   const user = useUserStore((s) => s.user)
   const clearUser = useUserStore((s) => s.clearUser)
   const clearHistory = useHistoryStore((s) => s.clearHistory)
@@ -32,126 +17,58 @@ function UserMenu({ size = 24, showName = false }) {
   const isPro =
     user?.member || user?.isPro || (user?.plan && user.plan !== 'free')
 
-  useEffect(() => {
-    function handlePointerDown(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setOpen(false)
-      }
-    }
-    if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
-
-  useEffect(() => {
-    const handler = () => setShortcutsOpen(true)
-    document.addEventListener('open-shortcuts', handler)
-    return () => document.removeEventListener('open-shortcuts', handler)
-  }, [])
+  if (!user) {
+    return (
+      <div className={`header-section user-menu ${showName ? 'with-name' : ''}`}>
+        <Avatar width={size} height={size} />
+        {showName && (
+          <Link to="/login" className="username login-btn">
+            {t.navRegister}/{t.navLogin}
+          </Link>
+        )}
+      </div>
+    )
+  }
 
   return (
-    <div className="header-section user-menu" ref={menuRef}>
-      {user ? (
-        <>
-          <button onClick={() => setOpen(!open)} className={showName ? 'with-name' : ''}>
-            <Avatar width={size} height={size} />
-            {showName ? (
-              <div className="info">
-                <span className="username">{username}</span>
-                {isPro && <ProTag />}
-              </div>
-            ) : (
-              isPro && <ProTag />
-            )}
-          </button>
-          {open && (
-            <div className="menu">
-              <div className="menu-header">
-                <div className="avatar">
-                  <Avatar width={32} height={32} />
-                  {isPro && <ProTag small />}
-                </div>
-                <div className="username">{username}</div>
-              </div>
-              <ul>
-                {!isPro && (
-                  <li onClick={() => setUpgradeOpen(true)}>
-                    <span className="icon">💳</span>{t.upgrade}
-                  </li>
-                )}
-                <li onClick={() => setProfileOpen(true)}>
-                  <span className="icon">👤</span>{t.profile}
-                </li>
-                <li onClick={() => setSettingsOpen(true)}>
-                  <span className="icon">⚙️</span>{t.settings}
-                </li>
-                <li onClick={() => setShortcutsOpen(true)}>
-                  <span className="icon">⌨️</span>{t.shortcuts}
-                </li>
-              </ul>
-              <ul>
-                <li>
-                  <span className="icon">❓</span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setHelpOpen(true)
-                      setOpen(false)
-                    }}
-                    className="menu-btn"
-                  >
-                    {t.help}
-                  </button>
-                </li>
-                <li>
-                  <span className="icon">🔑</span>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setLogoutOpen(true)
-                      setOpen(false)
-                    }}
-                    className="menu-btn"
-                  >
-                    {t.logout}
-                  </button>
-                </li>
-              </ul>
-            </div>
-          )}
-          <ProfileModal open={profileOpen} onClose={() => setProfileOpen(false)} />
-          {!isPro && (
-            <UpgradeModal
-              open={upgradeOpen}
-              onClose={() => setUpgradeOpen(false)}
+    <UserMenuModals
+      isPro={isPro}
+      user={user}
+      clearUser={clearUser}
+      clearHistory={clearHistory}
+    >
+      {({
+        openProfile,
+        openSettings,
+        openShortcuts,
+        openHelp,
+        openUpgrade,
+        openLogout
+      }) => (
+        <UserMenuButton
+          size={size}
+          showName={showName}
+          isPro={isPro}
+          username={username}
+        >
+          {({ open, setOpen }) => (
+            <UserMenuDropdown
+              open={open}
+              setOpen={setOpen}
+              t={t}
+              isPro={isPro}
+              username={username}
+              openProfile={openProfile}
+              openSettings={openSettings}
+              openShortcuts={openShortcuts}
+              openHelp={openHelp}
+              openUpgrade={openUpgrade}
+              openLogout={openLogout}
             />
           )}
-        </>
-      ) : (
-        <div className={showName ? 'with-name' : ''}>
-          <Avatar width={size} height={size} />
-          {showName && (
-            <Link to="/login" className="username login-btn">
-              {t.navRegister}/{t.navLogin}
-            </Link>
-          )}
-        </div>
+        </UserMenuButton>
       )}
-      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
-      <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
-      <ShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
-      <LogoutConfirmModal
-        open={logoutOpen}
-        onConfirm={() => {
-          clearHistory()
-          clearUser()
-          setLogoutOpen(false)
-        }}
-        onCancel={() => setLogoutOpen(false)}
-        email={user?.email || ''}
-      />
-    </div>
+    </UserMenuModals>
   )
 }
 

--- a/glancy-site/src/components/Header/UserMenuButton.jsx
+++ b/glancy-site/src/components/Header/UserMenuButton.jsx
@@ -1,0 +1,39 @@
+import { useState, useRef, useEffect } from 'react'
+import Avatar from '../Avatar.jsx'
+import ProTag from './ProTag.jsx'
+
+function UserMenuButton({ size, showName, isPro, username, children }) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef(null)
+
+  useEffect(() => {
+    function handlePointerDown(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown)
+    }
+    return () => document.removeEventListener('pointerdown', handlePointerDown)
+  }, [open])
+
+  return (
+    <div className="header-section user-menu" ref={menuRef}>
+      <button onClick={() => setOpen(!open)} className={showName ? 'with-name' : ''}>
+        <Avatar width={size} height={size} />
+        {showName ? (
+          <div className="info">
+            <span className="username">{username}</span>
+            {isPro && <ProTag />}
+          </div>
+        ) : (
+          isPro && <ProTag />
+        )}
+      </button>
+      {children({ open, setOpen })}
+    </div>
+  )
+}
+
+export default UserMenuButton

--- a/glancy-site/src/components/Header/UserMenuDropdown.jsx
+++ b/glancy-site/src/components/Header/UserMenuDropdown.jsx
@@ -1,0 +1,79 @@
+import Avatar from '../Avatar.jsx'
+import ProTag from './ProTag.jsx'
+
+function UserMenuDropdown({
+  open,
+  setOpen,
+  t,
+  isPro,
+  username,
+  openProfile,
+  openSettings,
+  openShortcuts,
+  openHelp,
+  openUpgrade,
+  openLogout
+}) {
+  if (!open) return null
+  return (
+    <div className="menu">
+      <div className="menu-header">
+        <div className="avatar">
+          <Avatar width={32} height={32} />
+          {isPro && <ProTag small />}
+        </div>
+        <div className="username">{username}</div>
+      </div>
+      <ul>
+        {!isPro && (
+          <li onClick={() => openUpgrade()}>
+            <span className="icon">💳</span>
+            {t.upgrade}
+          </li>
+        )}
+        <li onClick={openProfile}>
+          <span className="icon">👤</span>
+          {t.profile}
+        </li>
+        <li onClick={openSettings}>
+          <span className="icon">⚙️</span>
+          {t.settings}
+        </li>
+        <li onClick={openShortcuts}>
+          <span className="icon">⌨️</span>
+          {t.shortcuts}
+        </li>
+      </ul>
+      <ul>
+        <li>
+          <span className="icon">❓</span>
+          <button
+            type="button"
+            onClick={() => {
+              openHelp()
+              setOpen(false)
+            }}
+            className="menu-btn"
+          >
+            {t.help}
+          </button>
+        </li>
+        <li>
+          <span className="icon">🔑</span>
+          <button
+            type="button"
+            onClick={() => {
+              openLogout()
+              setOpen(false)
+            }}
+            className="menu-btn"
+          >
+            {t.logout}
+          </button>
+        </li>
+      </ul>
+    </div>
+  )
+}
+
+export default UserMenuDropdown

--- a/glancy-site/src/components/Header/UserMenuModals.jsx
+++ b/glancy-site/src/components/Header/UserMenuModals.jsx
@@ -1,0 +1,56 @@
+import { useState, useEffect } from 'react'
+import HelpModal from '../HelpModal.jsx'
+import SettingsModal from '../SettingsModal.jsx'
+import ShortcutsModal from '../ShortcutsModal.jsx'
+import ProfileModal from '../ProfileModal.jsx'
+import UpgradeModal from '../UpgradeModal.jsx'
+import LogoutConfirmModal from '../LogoutConfirmModal.jsx'
+
+function UserMenuModals({ isPro, user, clearUser, clearHistory, children }) {
+  const [helpOpen, setHelpOpen] = useState(false)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+  const [profileOpen, setProfileOpen] = useState(false)
+  const [upgradeOpen, setUpgradeOpen] = useState(false)
+  const [logoutOpen, setLogoutOpen] = useState(false)
+
+  useEffect(() => {
+    const handler = () => setShortcutsOpen(true)
+    document.addEventListener('open-shortcuts', handler)
+    return () => document.removeEventListener('open-shortcuts', handler)
+  }, [])
+
+  const handlers = {
+    openHelp: () => setHelpOpen(true),
+    openSettings: () => setSettingsOpen(true),
+    openShortcuts: () => setShortcutsOpen(true),
+    openProfile: () => setProfileOpen(true),
+    openUpgrade: () => setUpgradeOpen(true),
+    openLogout: () => setLogoutOpen(true)
+  }
+
+  return (
+    <>
+      {children(handlers)}
+      <ProfileModal open={profileOpen} onClose={() => setProfileOpen(false)} />
+      {!isPro && (
+        <UpgradeModal open={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
+      )}
+      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
+      <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <ShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
+      <LogoutConfirmModal
+        open={logoutOpen}
+        onConfirm={() => {
+          clearHistory()
+          clearUser()
+          setLogoutOpen(false)
+        }}
+        onCancel={() => setLogoutOpen(false)}
+        email={user?.email || ''}
+      />
+    </>
+  )
+}
+
+export default UserMenuModals


### PR DESCRIPTION
### Summary
- extract `UserMenuButton` for open state and toggle logic
- move dropdown actions into `UserMenuDropdown`
- manage all related modals inside `UserMenuModals`
- compose new components in a simplified `UserMenu`

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_68826e684ff8833295b1a13333e09547