### PR TITLE
[fix] remove unused locale fetch

### DIFF
--- a/glancy-site/src/components/PhoneInput.jsx
+++ b/glancy-site/src/components/PhoneInput.jsx
@@ -1,15 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
-import { API_PATHS } from '../config/api.js'
-import { createApiClient } from '../api/client.js'
-import { getLocale } from '../api/locale.js'
 import { useLocale } from '../LocaleContext.jsx'
 import '../AuthPage.css'
-
-const request = createApiClient({
-  headers: {
-    'Accept-Language': navigator.language || 'en-US'
-  }
-})
 
 const CODE_LIST = [
   { country: 'CN', code: '+86' },
@@ -29,17 +20,13 @@ function PhoneInput({ onChange, placeholder = 'Phone number' }) {
   const [number, setNumber] = useState('')
   const [open, setOpen] = useState(false)
   const ref = useRef(null)
-  const { locale, setLocale } = useLocale()
+  const { locale } = useLocale()
 
   useEffect(() => {
-    request(API_PATHS.locale)
-      .then((data) => {
-        setLocale(data)
-        const found = CODE_LIST.find((c) => c.country === data.country)
-        if (found) setCode(found.code)
-      })
-      .catch(() => {})
-  }, [locale, setLocale])
+    if (!locale) return
+    const found = CODE_LIST.find((c) => c.country === locale.country)
+    if (found) setCode(found.code)
+  }, [locale])
 
   useEffect(() => {
     const handler = (e) => {


### PR DESCRIPTION
### Summary
- clean up PhoneInput locale logic

### Testing
- `npm run lint` *(fails: UserMenu lint errors)*
- `npx eslint src/components/PhoneInput.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882742b32448332bf743adb55d3505b