### PR TITLE
[fix] cleanup user menu component

### DIFF
--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -1,4 +1,3 @@
-import { useRef, useState, useEffect } from 'react'
 import { useUser, useHistory } from '../../context/AppContext.jsx'
 import { useLanguage } from '../../LanguageContext.jsx'
 import './Header.css'
@@ -9,14 +8,6 @@ import UserMenuDropdown from './UserMenuDropdown.jsx'
 import UserMenuModals from './UserMenuModals.jsx'
 
 function UserMenu({ size = 24, showName = false }) {
-  const [open, setOpen] = useState(false)
-  const [helpOpen, setHelpOpen] = useState(false)
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const [shortcutsOpen, setShortcutsOpen] = useState(false)
-  const [profileOpen, setProfileOpen] = useState(false)
-  const [upgradeOpen, setUpgradeOpen] = useState(false)
-  const [logoutOpen, setLogoutOpen] = useState(false)
-  const menuRef = useRef(null)
   const { user, clearUser } = useUser()
   const { clearHistory } = useHistory()
   const { t } = useLanguage()

--- a/glancy-site/src/components/PhoneInput.jsx
+++ b/glancy-site/src/components/PhoneInput.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { API_PATHS } from '../config/api.js'
 import { createApiClient } from '../api/client.js'
-import { getLocale } from '../api/locale.js'
 import { useLocale } from '../LocaleContext.jsx'
 import '../AuthPage.css'
 


### PR DESCRIPTION
### Summary
- remove unused state from `UserMenu` and depend on injected state
- clear unused import in `PhoneInput`

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68827428d9948332b831dcc8e5422093