### PR TITLE
[fix] improve error handling

### DIFF
--- a/glancy-site/src/Faq.jsx
+++ b/glancy-site/src/Faq.jsx
@@ -3,17 +3,24 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import { useApi } from './hooks/useApi.js'
+import MessagePopup from './components/MessagePopup.jsx'
 
 function Faq() {
   const { t } = useLanguage()
   const [items, setItems] = useState([])
   const api = useApi()
+  const [popupOpen, setPopupOpen] = useState(false)
+  const [popupMsg, setPopupMsg] = useState('')
 
   useEffect(() => {
     api(API_PATHS.faqs)
       .then((data) => setItems(data))
-      .catch(() => {})
-  }, [api])
+      .catch((err) => {
+        console.error(err)
+        setPopupMsg(t.fail)
+        setPopupOpen(true)
+      })
+  }, [api, t])
 
   return (
     <div className="App">
@@ -26,6 +33,11 @@ function Faq() {
           </li>
         ))}
       </ul>
+      <MessagePopup
+        open={popupOpen}
+        message={popupMsg}
+        onClose={() => setPopupOpen(false)}
+      />
     </div>
   )
 }

--- a/glancy-site/src/LocaleContext.jsx
+++ b/glancy-site/src/LocaleContext.jsx
@@ -19,7 +19,9 @@ export function LocaleProvider({ children }) {
         setLocale(data)
         localStorage.setItem('locale', JSON.stringify(data))
       })
-      .catch(() => {})
+      .catch((err) => {
+        console.error(err)
+      })
   }, [locale])
 
   return (

--- a/glancy-site/src/Preferences.jsx
+++ b/glancy-site/src/Preferences.jsx
@@ -40,8 +40,12 @@ function Preferences() {
         localStorage.setItem('dictionaryModel', dm)
         setTheme(data.theme || 'system')
       })
-      .catch(() => {})
-  }, [setTheme, user])
+      .catch((err) => {
+        console.error(err)
+        setPopupMsg(t.fail)
+        setPopupOpen(true)
+      })
+  }, [setTheme, t, user, api])
 
   const handleSave = async (e) => {
     e.preventDefault()

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -40,8 +40,12 @@ function Profile({ onCancel }) {
         setGoal(data.goal)
         setAvatar(data.avatar)
       })
-      .catch(() => {})
-  }, [])
+      .catch((err) => {
+        console.error(err)
+        setPopupMsg(t.fail)
+        setPopupOpen(true)
+      })
+  }, [api, t])
 
   const handleSave = async (e) => {
     e.preventDefault()

--- a/glancy-site/src/api/client.js
+++ b/glancy-site/src/api/client.js
@@ -19,7 +19,10 @@ export function createApiClient({ token, headers: defaultHeaders = {} } = {}) {
 
     const resp = await fetch(url, { ...options, headers: mergedHeaders })
     if (!resp.ok) {
-      const text = await resp.text().catch(() => '')
+      const text = await resp.text().catch((err) => {
+        console.error(err)
+        return ''
+      })
       throw new Error(extractMessage(text) || 'Request failed')
     }
     const contentType = resp.headers.get('content-type') || ''

--- a/glancy-site/src/store/historyStore.ts
+++ b/glancy-site/src/store/historyStore.ts
@@ -60,7 +60,9 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
               recordMap: { ...state.recordMap, [term]: record.id }
             }))
           })
-          .catch(() => {})
+          .catch((err) => {
+            console.error(err)
+          })
       }
       const unique = Array.from(new Set([term, ...get().history])).slice(0, 20)
       localStorage.setItem(STORAGE_KEY, JSON.stringify(unique))
@@ -68,7 +70,9 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     },
     clearHistory: async (user?: User | null) => {
       if (user) {
-        clearSearchRecords({ userId: user.id, token: user.token }).catch(() => {})
+        clearSearchRecords({ userId: user.id, token: user.token }).catch((err) => {
+          console.error(err)
+        })
       }
       localStorage.removeItem(STORAGE_KEY)
       set({ history: [], recordMap: {} })
@@ -77,7 +81,9 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
       if (user) {
         const id = get().recordMap[term]
         if (id) {
-          deleteSearchRecord({ userId: user.id, recordId: id, token: user.token }).catch(() => {})
+          deleteSearchRecord({ userId: user.id, recordId: id, token: user.token }).catch((err) => {
+            console.error(err)
+          })
         }
       }
       const updated = get().history.filter((t) => t !== term)
@@ -91,13 +97,17 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     favoriteHistory: async (term: string, user?: User | null) => {
         const id = get().recordMap[term]
         if (user && id) {
-          favoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch(() => {})
+          favoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch((err) => {
+            console.error(err)
+          })
         }
       },
     unfavoriteHistory: async (term: string, user?: User | null) => {
         const id = get().recordMap[term]
         if (user && id) {
-          unfavoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch(() => {})
+          unfavoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch((err) => {
+            console.error(err)
+          })
         }
       }
     }


### PR DESCRIPTION
### Summary
- add popup feedback in FAQ page
- show error message when loading preferences or profile fails
- log errors in history and locale stores
- log fetch failures in API client

### Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68827f81bd5483329ef3e37aea6e021e