### PR TITLE
[refactor] move inline styles to css modules

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -12,6 +12,7 @@ import voiceDark from './assets/voice-button-dark.svg'
 import { useWordsApi } from './api/words.js'
 import { useLanguage } from './LanguageContext.jsx'
 import './App.css'
+import styles from './App.module.css'
 import Layout from './components/Layout.jsx'
 import HistoryDisplay from './components/HistoryDisplay.jsx'
 
@@ -234,7 +235,7 @@ function App() {
             placeholder={t.inputPlaceholder}
             value={text}
             onChange={(e) => setText(e.target.value)}
-            style={{ borderRadius: '20px' }}
+            className={styles.roundedInput}
           />
           <button type="submit">
             <img

--- a/glancy-site/src/App.module.css
+++ b/glancy-site/src/App.module.css
@@ -1,0 +1,3 @@
+.roundedInput {
+  border-radius: var(--radius-lg);
+}

--- a/glancy-site/src/components/DesktopTopBar.jsx
+++ b/glancy-site/src/components/DesktopTopBar.jsx
@@ -1,6 +1,7 @@
 import './DesktopTopBar.css'
 import './TopBarCommon.css'
 import './Header/Header.css'
+import styles from './DesktopTopBar.module.css'
 import TopBarActions from './TopBarActions.jsx'
 
 function DesktopTopBar({
@@ -16,12 +17,8 @@ function DesktopTopBar({
     <header className="desktop-topbar">
       <button
         type="button"
-        className="back-btn"
+        className={`back-btn ${showBack ? styles.visible : styles.hidden}`}
         onClick={onBack}
-        style={{
-          visibility: showBack ? 'visible' : 'hidden',
-          pointerEvents: showBack ? 'auto' : 'none'
-        }}
       >
         ←
       </button>

--- a/glancy-site/src/components/DesktopTopBar.module.css
+++ b/glancy-site/src/components/DesktopTopBar.module.css
@@ -1,0 +1,9 @@
+.visible {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.hidden {
+  visibility: hidden;
+  pointer-events: none;
+}

--- a/glancy-site/src/components/MessagePopup.jsx
+++ b/glancy-site/src/components/MessagePopup.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import './MessagePopup.css'
+import styles from './MessagePopup.module.css'
 
 function MessagePopup({ open, message, onClose }) {
   useEffect(() => {
@@ -16,7 +17,11 @@ function MessagePopup({ open, message, onClose }) {
     <div className="popup-overlay" onClick={onClose}>
       <div className="popup" onClick={(e) => e.stopPropagation()}>
         <div>{message}</div>
-        <button type="button" onClick={onClose} style={{ marginTop: '1rem' }}>
+        <button
+          type="button"
+          onClick={onClose}
+          className={styles.closeBtn}
+        >
           Close
         </button>
       </div>

--- a/glancy-site/src/components/MessagePopup.module.css
+++ b/glancy-site/src/components/MessagePopup.module.css
@@ -1,0 +1,3 @@
+.closeBtn {
+  margin-top: var(--space-3);
+}

--- a/glancy-site/src/components/MobileTopBar.jsx
+++ b/glancy-site/src/components/MobileTopBar.jsx
@@ -5,6 +5,7 @@ import darkIcon from '../assets/glancy-web-dark.svg'
 import TopBarActions from './TopBarActions.jsx'
 import './TopBarCommon.css'
 import './MobileTopBar.css'
+import styles from './MobileTopBar.module.css'
 
 function MobileTopBar({
   term = '',
@@ -26,12 +27,8 @@ function MobileTopBar({
       </button>
       <button
         type="button"
-        className="back-btn"
+        className={`back-btn ${showBack ? styles.visible : styles.hidden}`}
         onClick={onBack}
-        style={{
-          visibility: showBack ? 'visible' : 'hidden',
-          pointerEvents: showBack ? 'auto' : 'none'
-        }}
       >
         ←
       </button>

--- a/glancy-site/src/components/MobileTopBar.module.css
+++ b/glancy-site/src/components/MobileTopBar.module.css
@@ -1,0 +1,9 @@
+.visible {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.hidden {
+  visibility: hidden;
+  pointer-events: none;
+}


### PR DESCRIPTION
### Summary
- create CSS modules for App and components
- replace inline styles with classes referencing design tokens

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6882803d4d6c8332a912caa38340bca4