### PR TITLE
[feature] add icon component library

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -9,4 +9,17 @@ Common variables are defined under `src/theme` and imported across modules.
 - Buttons share base styles defined in `index.css`.
 - Modals should use `Modal.jsx` as wrapper and apply custom classes.
 
+### Icons
+SVG files live under `src/assets` and are exported as React components from
+`src/components/Icon`.
+Use these components instead of `<img>` when adding icons:
+
+```jsx
+import { GoogleIcon } from '../components/Icon'
+
+function Example() {
+  return <GoogleIcon width={24} height={24} />
+}
+```
+
 Future pull requests should follow these conventions.

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -5,10 +5,12 @@ import { useNavigate } from 'react-router-dom'
 import { useTheme } from './ThemeContext.jsx'
 import { translations } from './translations.js'
 import DictionaryEntry from './components/DictionaryEntry.jsx'
-import sendLight from './assets/send-button-light.svg'
-import sendDark from './assets/send-button-dark.svg'
-import voiceLight from './assets/voice-button-light.svg'
-import voiceDark from './assets/voice-button-dark.svg'
+import {
+  SendButtonLightIcon,
+  SendButtonDarkIcon,
+  VoiceButtonLightIcon,
+  VoiceButtonDarkIcon
+} from './components/Icon'
 import { useWordsApi } from './api/words.js'
 import { useLanguage } from './LanguageContext.jsx'
 import './App.css'
@@ -27,8 +29,10 @@ function App() {
   const { loadHistory, addHistory, unfavoriteHistory } = useHistory()
   const { theme, resolvedTheme, setTheme } = useTheme()
   const inputRef = useRef(null)
-  const sendIcon = resolvedTheme === 'dark' ? sendDark : sendLight
-  const voiceIcon = resolvedTheme === 'dark' ? voiceDark : voiceLight
+  const SendIcon =
+    resolvedTheme === 'dark' ? SendButtonDarkIcon : SendButtonLightIcon
+  const VoiceIcon =
+    resolvedTheme === 'dark' ? VoiceButtonDarkIcon : VoiceButtonLightIcon
   const [showFavorites, setShowFavorites] = useState(false)
   const [showHistory, setShowHistory] = useState(false)
   const [fromFavorites, setFromFavorites] = useState(false)
@@ -237,10 +241,11 @@ function App() {
             style={{ borderRadius: '20px' }}
           />
           <button type="submit">
-            <img
-              src={text.trim() === '' ? voiceIcon : sendIcon}
-              alt={text.trim() === '' ? 'voice' : 'send'}
-            />
+            {text.trim() === '' ? (
+              <VoiceIcon alt="voice" />
+            ) : (
+              <SendIcon alt="send" />
+            )}
           </button>
         </form>
         <div className="icp">

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -7,13 +7,15 @@ import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
 import { useApi } from './hooks/useApi.js'
 import { useUser } from './context/AppContext.jsx'
-import googleIcon from './assets/google.svg'
-import appleIcon from './assets/apple.svg'
-import phoneIcon from './assets/phone.svg'
-import wechatIcon from './assets/wechat.svg'
-import emailIcon from './assets/email.svg'
-import lightIcon from './assets/glancy-web-light.svg'
-import darkIcon from './assets/glancy-web-dark.svg'
+import {
+  GoogleIcon,
+  AppleIcon,
+  PhoneIcon,
+  WechatIcon,
+  EmailIcon,
+  GlancyWebLightIcon,
+  GlancyWebDarkIcon
+} from './components/Icon'
 import { useTheme } from './ThemeContext.jsx'
 
 function Register() {
@@ -25,7 +27,7 @@ function Register() {
   const navigate = useNavigate()
   const { setUser } = useUser()
   const { resolvedTheme } = useTheme()
-  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
+  const BrandIcon = resolvedTheme === 'dark' ? GlancyWebDarkIcon : GlancyWebLightIcon
   const api = useApi()
 
   const validateAccount = () => {
@@ -109,17 +111,17 @@ function Register() {
 
   const methodOrder = ['phone', 'email', 'wechat', 'apple', 'google']
   const icons = {
-    email: emailIcon,
-    phone: phoneIcon,
-    wechat: wechatIcon,
-    apple: appleIcon,
-    google: googleIcon
+    email: EmailIcon,
+    phone: PhoneIcon,
+    wechat: WechatIcon,
+    apple: AppleIcon,
+    google: GoogleIcon
   }
 
   return (
     <div className="auth-page">
       <Link to="/" className="auth-close">×</Link>
-      <img className="auth-logo" src={icon} alt="Glancy" />
+      <BrandIcon className="auth-logo" />
       <div className="auth-brand">Glancy</div>
       <h1 className="auth-title">Create an account</h1>
       {renderForm()}
@@ -140,7 +142,10 @@ function Register() {
                 formMethods.includes(m) ? setMethod(m) : alert('Not implemented')
               }
             >
-              <img src={icons[m]} alt={m} />
+              {(() => {
+                const Icon = icons[m]
+                return <Icon alt={m} />
+              })()}
             </button>
           ))}
       </div>

--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -1,13 +1,12 @@
 import { useLanguage } from '../LanguageContext.jsx'
 import { useTheme } from '../ThemeContext.jsx'
-import lightIcon from '../assets/glancy-web-light.svg'
-import darkIcon from '../assets/glancy-web-dark.svg'
+import { GlancyWebLightIcon, GlancyWebDarkIcon } from './Icon'
 import UserMenu from './Header/UserMenu.jsx'
 
 function Brand() {
   const { lang } = useLanguage()
   const { resolvedTheme } = useTheme()
-  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
+  const BrandIcon = resolvedTheme === 'dark' ? GlancyWebDarkIcon : GlancyWebLightIcon
   const text = lang === 'zh' ? '格律词典' : 'Glancy'
 
   const handleClick = () => {
@@ -17,7 +16,7 @@ function Brand() {
   return (
     <div className="sidebar-brand">
       <div className="brand-main" onClick={handleClick}>
-        <img src={icon} alt="Glancy" />
+        <BrandIcon alt="Glancy" />
         <span>{text}</span>
       </div>
       <div className="mobile-user-menu">

--- a/glancy-site/src/components/Icon/index.jsx
+++ b/glancy-site/src/components/Icon/index.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import apple from '../../assets/apple.svg'
+import glancyWebDark from '../../assets/glancy-web-dark.svg'
+import glancyWebLight from '../../assets/glancy-web-light.svg'
+import sendButtonDark from '../../assets/send-button-dark.svg'
+import sendButtonLight from '../../assets/send-button-light.svg'
+import defaultUserAvatarDark from '../../assets/default-user-avatar-dark.svg'
+import defaultUserAvatarLight from '../../assets/default-user-avatar-light.svg'
+import google from '../../assets/google.svg'
+import user from '../../assets/user.svg'
+import email from '../../assets/email.svg'
+import phone from '../../assets/phone.svg'
+import voiceButtonDark from '../../assets/voice-button-dark.svg'
+import voiceButtonLight from '../../assets/voice-button-light.svg'
+import glancyDark from '../../assets/glancy-dark.svg'
+import glancyLight from '../../assets/glancy-light.svg'
+import proTagDark from '../../assets/pro-tag-dark.svg'
+import proTagLight from '../../assets/pro-tag-light.svg'
+import wechat from '../../assets/wechat.svg'
+
+function createIcon(src, alt) {
+  return function Icon(props) {
+    return <img src={src} alt={alt} {...props} />
+  }
+}
+
+export const AppleIcon = createIcon(apple, 'apple')
+export const GlancyWebDarkIcon = createIcon(glancyWebDark, 'glancy-web-dark')
+export const GlancyWebLightIcon = createIcon(glancyWebLight, 'glancy-web-light')
+export const SendButtonDarkIcon = createIcon(sendButtonDark, 'send-button-dark')
+export const SendButtonLightIcon = createIcon(sendButtonLight, 'send-button-light')
+export const DefaultUserAvatarDarkIcon = createIcon(defaultUserAvatarDark, 'default-user-avatar-dark')
+export const DefaultUserAvatarLightIcon = createIcon(defaultUserAvatarLight, 'default-user-avatar-light')
+export const GoogleIcon = createIcon(google, 'google')
+export const UserIcon = createIcon(user, 'user')
+export const EmailIcon = createIcon(email, 'email')
+export const PhoneIcon = createIcon(phone, 'phone')
+export const VoiceButtonDarkIcon = createIcon(voiceButtonDark, 'voice-button-dark')
+export const VoiceButtonLightIcon = createIcon(voiceButtonLight, 'voice-button-light')
+export const GlancyDarkIcon = createIcon(glancyDark, 'glancy-dark')
+export const GlancyLightIcon = createIcon(glancyLight, 'glancy-light')
+export const ProTagDarkIcon = createIcon(proTagDark, 'pro-tag-dark')
+export const ProTagLightIcon = createIcon(proTagLight, 'pro-tag-light')
+export const WechatIcon = createIcon(wechat, 'wechat')
+
+export default {
+  AppleIcon,
+  GlancyWebDarkIcon,
+  GlancyWebLightIcon,
+  SendButtonDarkIcon,
+  SendButtonLightIcon,
+  DefaultUserAvatarDarkIcon,
+  DefaultUserAvatarLightIcon,
+  GoogleIcon,
+  UserIcon,
+  EmailIcon,
+  PhoneIcon,
+  VoiceButtonDarkIcon,
+  VoiceButtonLightIcon,
+  GlancyDarkIcon,
+  GlancyLightIcon,
+  ProTagDarkIcon,
+  ProTagLightIcon,
+  WechatIcon
+}


### PR DESCRIPTION
### Summary
- centralize icons under `src/components/Icon`
- update Register, Brand and App to use icon components
- document icon usage in STYLE_GUIDE

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68828047d1c883328500264115b58489