### PR TITLE
[feature] centralize locale map

### DIFF
--- a/glancy-site/server.js
+++ b/glancy-site/server.js
@@ -2,6 +2,7 @@ import express from 'express'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import geoip from 'geoip-lite'
+import { COUNTRY_LANGUAGE_MAP } from './src/config/countryLanguageMap.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -20,17 +21,7 @@ app.get('/api/locale', (req, res) => {
     '127.0.0.1'
   const geo = geoip.lookup(ip)
   const country = geo?.country || 'US'
-  const map = {
-    CN: 'zh',
-    US: 'en',
-    GB: 'en',
-    DE: 'de',
-    FR: 'fr',
-    RU: 'ru',
-    JP: 'ja',
-    ES: 'es'
-  }
-  const lang = map[country] || 'en'
+  const lang = COUNTRY_LANGUAGE_MAP[country] || 'en'
   res.json({ country, lang })
 })
 

--- a/glancy-site/src/config/countryLanguageMap.js
+++ b/glancy-site/src/config/countryLanguageMap.js
@@ -1,0 +1,11 @@
+export const COUNTRY_LANGUAGE_MAP = {
+  CN: 'zh',
+  US: 'en',
+  GB: 'en',
+  DE: 'de',
+  FR: 'fr',
+  RU: 'ru',
+  JP: 'ja',
+  ES: 'es'
+}
+

--- a/glancy-site/src/config/index.js
+++ b/glancy-site/src/config/index.js
@@ -1,2 +1,3 @@
 export * from './api.js'
 export * from './languages.js'
+export * from './countryLanguageMap.js'


### PR DESCRIPTION
### Summary
- define COUNTRY_LANGUAGE_MAP in config
- use COUNTRY_LANGUAGE_MAP in server

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688281d074648332a54422a75f260d28