### PR TITLE
[refactor] icon components

### DIFF
--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -7,14 +7,16 @@ import { API_PATHS } from './config/api.js'
 import { useUser } from './context/AppContext.jsx'
 import MessagePopup from './components/MessagePopup.jsx'
 import { useApi } from './hooks/useApi.js'
-import googleIcon from './assets/google.svg'
-import appleIcon from './assets/apple.svg'
-import phoneIcon from './assets/phone.svg'
-import wechatIcon from './assets/wechat.svg'
-import userIcon from './assets/user.svg'
-import emailIcon from './assets/email.svg'
-import lightIcon from './assets/glancy-web-light.svg'
-import darkIcon from './assets/glancy-web-dark.svg'
+import {
+  GoogleIcon,
+  AppleIcon,
+  PhoneIcon,
+  WechatIcon,
+  UserIcon,
+  EmailIcon,
+  GlancyWebLightIcon,
+  GlancyWebDarkIcon
+} from './components/Icon'
 import { useTheme } from './ThemeContext.jsx'
 
 function Login() {
@@ -27,7 +29,8 @@ function Login() {
   const [popupMsg, setPopupMsg] = useState('')
   const navigate = useNavigate()
   const { resolvedTheme } = useTheme()
-  const icon = resolvedTheme === 'dark' ? darkIcon : lightIcon
+  const BrandIcon =
+    resolvedTheme === 'dark' ? GlancyWebDarkIcon : GlancyWebLightIcon
 
   const handleSubmit = async (e) => {
     e.preventDefault()
@@ -91,18 +94,18 @@ function Login() {
 
   const methodOrder = ['username', 'email', 'phone', 'wechat', 'apple', 'google']
   const icons = {
-    username: userIcon,
-    email: emailIcon,
-    phone: phoneIcon,
-    wechat: wechatIcon,
-    apple: appleIcon,
-    google: googleIcon
+    username: UserIcon,
+    email: EmailIcon,
+    phone: PhoneIcon,
+    wechat: WechatIcon,
+    apple: AppleIcon,
+    google: GoogleIcon
   }
 
   return (
     <div className="auth-page">
       <Link to="/" className="auth-close">×</Link>
-      <img className="auth-logo" src={icon} alt="Glancy" />
+      <BrandIcon className="auth-logo" />
       <div className="auth-brand">Glancy</div>
       <h1 className="auth-title">Welcome back</h1>
       {renderForm()}
@@ -123,7 +126,10 @@ function Login() {
                 formMethods.includes(m) ? setMethod(m) : alert('Not implemented')
               }
             >
-              <img src={icons[m]} alt={m} />
+              {(() => {
+                const Icon = icons[m]
+                return <Icon alt={m} />
+              })()}
             </button>
           ))}
       </div>

--- a/glancy-site/src/components/Header/ProTag.jsx
+++ b/glancy-site/src/components/Header/ProTag.jsx
@@ -1,12 +1,12 @@
 import { useTheme } from '../../ThemeContext.jsx'
-import proLight from '../../assets/pro-tag-light.svg'
-import proDark from '../../assets/pro-tag-dark.svg'
+import { ProTagLightIcon, ProTagDarkIcon } from '../Icon'
 
 function ProTag({ small }) {
   const { resolvedTheme } = useTheme()
-  const src = resolvedTheme === 'dark' ? proDark : proLight
+  const IconComponent =
+    resolvedTheme === 'dark' ? ProTagDarkIcon : ProTagLightIcon
   const className = small ? 'pro-tag-small' : 'pro-tag'
-  return <img src={src} className={className} alt="PRO" />
+  return <IconComponent className={className} />
 }
 
 export default ProTag


### PR DESCRIPTION
### Summary
- use icon components in Login page
- update ProTag to use Icon exports

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883155a424c833296b9571c24d9eb59