### PR TITLE
[feature] add button component

### DIFF
--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import CodeButton from './components/CodeButton.jsx'
 import PhoneInput from './components/PhoneInput.jsx'
 import { useNavigate, Link } from 'react-router-dom'
+import { Button } from './components/index.js'
 import './AuthPage.css'
 import { API_PATHS } from './config/api.js'
 import { useUser } from './context/AppContext.jsx'
@@ -84,7 +85,7 @@ function Login() {
             <CodeButton onClick={handleSendCode} />
           )}
         </div>
-        <button type="submit" className="auth-primary-btn">Continue</button>
+        <Button type="submit" className="auth-primary-btn">Continue</Button>
       </form>
     )
   }
@@ -116,7 +117,7 @@ function Login() {
         {methodOrder
           .filter((m) => m !== method)
           .map((m) => (
-            <button
+            <Button
               key={m}
               type="button"
               onClick={() =>
@@ -124,7 +125,7 @@ function Login() {
               }
             >
               <img src={icons[m]} alt={m} />
-            </button>
+            </Button>
           ))}
       </div>
       <div className="auth-footer">

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -7,6 +7,7 @@ import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
 import { useApi } from './hooks/useApi.js'
 import { useUser } from './context/AppContext.jsx'
+import { Button } from './components/index.js'
 import {
   GoogleIcon,
   AppleIcon,
@@ -104,7 +105,7 @@ function Register() {
           />
           <CodeButton onClick={handleSendCode} />
         </div>
-        <button type="submit" className="auth-primary-btn">Continue</button>
+        <Button type="submit" className="auth-primary-btn">Continue</Button>
       </form>
     )
   }
@@ -135,7 +136,7 @@ function Register() {
         {methodOrder
           .filter((m) => m !== method)
           .map((m) => (
-            <button
+            <Button
               key={m}
               type="button"
               onClick={() =>
@@ -146,7 +147,7 @@ function Register() {
                 const Icon = icons[m]
                 return <Icon alt={m} />
               })()}
-            </button>
+            </Button>
           ))}
       </div>
       <div className="auth-footer">

--- a/glancy-site/src/components/Button/Button.jsx
+++ b/glancy-site/src/components/Button/Button.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import styles from './Button.module.css'
+
+function Button({ className = '', children, ...props }) {
+  return (
+    <button className={`${styles.button} ${className}`.trim()} {...props}>
+      {children}
+    </button>
+  )
+}
+
+export default Button

--- a/glancy-site/src/components/Button/Button.module.css
+++ b/glancy-site/src/components/Button/Button.module.css
@@ -1,0 +1,23 @@
+@import '../../theme/colors.css';
+@import '../../theme/variables.css';
+
+.button {
+  border-radius: var(--radius-md);
+  border: var(--btn-border);
+  padding: var(--btn-padding);
+  font-size: 1em;
+  font-weight: 500;
+  font-family: inherit;
+  background-color: transparent;
+  cursor: pointer;
+  transition: border-color 0.25s;
+}
+
+.button:hover {
+  border-color: var(--highlight-color);
+}
+
+.button:focus,
+.button:focus-visible {
+  outline: none;
+}

--- a/glancy-site/src/components/index.js
+++ b/glancy-site/src/components/index.js
@@ -1,0 +1,1 @@
+export { default as Button } from './Button/Button.jsx'

--- a/glancy-site/src/index.css
+++ b/glancy-site/src/index.css
@@ -149,27 +149,4 @@ h1 {
   line-height: 1.1;
 }
 
-button {
-  border-radius: var(--radius-md);
-  border: var(--btn-border);
-  padding: var(--btn-padding);
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: transparent;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: var(--highlight-color);
-}
-button:focus,
-button:focus-visible {
-  outline: none;
-}
-
-
-:root[data-theme='light'] button {
-  background-color: transparent;
-}
 


### PR DESCRIPTION
### Summary
- create a reusable `Button` component
- remove global button styles and use design tokens
- update login and register pages to use the new component

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_688315de4d9883328e35a3f840565816