### PR TITLE
[feature] lazy load pages

### DIFF
--- a/glancy-site/src/components/Loader.jsx
+++ b/glancy-site/src/components/Loader.jsx
@@ -1,0 +1,11 @@
+import './Loader.module.css'
+
+function Loader() {
+  return (
+    <div className="loader">
+      <div className="spinner" />
+    </div>
+  )
+}
+
+export default Loader

--- a/glancy-site/src/components/Loader.module.css
+++ b/glancy-site/src/components/Loader.module.css
@@ -1,0 +1,21 @@
+.loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 4px solid var(--border-color, #ccc);
+  border-top-color: var(--highlight-color);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -1,10 +1,12 @@
-import { StrictMode } from 'react'
+import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
-import App from './App.jsx'
-import Login from './Login.jsx'
-import Register from './Register.jsx'
+import Loader from './components/Loader.jsx'
+
+const App = lazy(() => import('./App.jsx'))
+const Login = lazy(() => import('./Login.jsx'))
+const Register = lazy(() => import('./Register.jsx'))
 import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 import { AppProvider } from './context/AppContext.jsx'
@@ -22,11 +24,13 @@ createRoot(document.getElementById('root')).render(
       <LanguageProvider>
         <ThemeProvider>
           <BrowserRouter>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-              <Route path="/register" element={<Register />} />
-              <Route path="*" element={<App />} />
-            </Routes>
+            <Suspense fallback={<Loader />}>
+              <Routes>
+                <Route path="/login" element={<Login />} />
+                <Route path="/register" element={<Register />} />
+                <Route path="*" element={<App />} />
+              </Routes>
+            </Suspense>
           </BrowserRouter>
         </ThemeProvider>
       </LanguageProvider>


### PR DESCRIPTION
### Summary
- use `React.lazy` with `Suspense` for page routing
- add simple loader component for async chunks
- verify that build output shows split chunks

### Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688315f6c25c8332b0959742f36440dd