### PR TITLE
[feature] add useOutsideToggle hook

### DIFF
--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -106,7 +106,7 @@ function Login() {
   return (
     <div className={styles['auth-page']}>
       <Link to="/" className={styles['auth-close']}>×</Link>
-      <img className={styles['auth-logo']} src={icon} alt="Glancy" />
+      <img className={styles['auth-logo']} src={BrandIcon} alt="Glancy" />
       <div className={styles['auth-brand']}>Glancy</div>
       <h1 className={styles['auth-title']}>Welcome back</h1>
       {renderForm()}

--- a/glancy-site/src/components/Header/UserMenuButton.jsx
+++ b/glancy-site/src/components/Header/UserMenuButton.jsx
@@ -1,22 +1,9 @@
-import { useState, useRef, useEffect } from 'react'
+import useOutsideToggle from '../../hooks/useOutsideToggle.js'
 import Avatar from '../Avatar.jsx'
 import ProTag from './ProTag.jsx'
 
 function UserMenuButton({ size, showName, isPro, username, children }) {
-  const [open, setOpen] = useState(false)
-  const menuRef = useRef(null)
-
-  useEffect(() => {
-    function handlePointerDown(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setOpen(false)
-      }
-    }
-    if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
+  const { open, setOpen, ref: menuRef } = useOutsideToggle(false)
 
   return (
     <div className="header-section user-menu" ref={menuRef}>

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,27 +1,22 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { useHistory, useFavorites, useUser } from '../../context/AppContext.jsx'
 import { useLanguage } from '../../LanguageContext.jsx'
 import './Sidebar.css'
+import useOutsideToggle from '../../hooks/useOutsideToggle.js'
 
 function HistoryList({ onSelect }) {
   const { history, loadHistory, removeHistory, favoriteHistory } = useHistory()
   const { toggleFavorite } = useFavorites()
   const { user } = useUser()
   const [openIndex, setOpenIndex] = useState(null)
-  const listRef = useRef(null)
+  const { ref: listRef, open, setOpen } = useOutsideToggle(false)
   const { t } = useLanguage()
 
   useEffect(() => {
-    function handlePointerDown(e) {
-      if (listRef.current && !listRef.current.contains(e.target)) {
-        setOpenIndex(null)
-      }
+    if (!open) {
+      setOpenIndex(null)
     }
-    if (openIndex !== null) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [openIndex])
+  }, [open])
 
   useEffect(() => {
     loadHistory(user)
@@ -43,7 +38,9 @@ function HistoryList({ onSelect }) {
                 className="history-action"
                 onClick={(e) => {
                   e.stopPropagation()
-                  setOpenIndex(openIndex === i ? null : i)
+                  const isOpen = openIndex === i
+                  setOpenIndex(isOpen ? null : i)
+                  setOpen(!isOpen)
                 }}
               >
                 ⋮
@@ -57,6 +54,7 @@ function HistoryList({ onSelect }) {
                       favoriteHistory(h, user)
                       toggleFavorite(h)
                       setOpenIndex(null)
+                      setOpen(false)
                     }}
                   >
                     ★ {t.favoriteAction}
@@ -68,6 +66,7 @@ function HistoryList({ onSelect }) {
                       e.stopPropagation()
                       removeHistory(h, user)
                       setOpenIndex(null)
+                      setOpen(false)
                     }}
                   >
                     🗑 {t.deleteAction}

--- a/glancy-site/src/components/Toolbar/ModelSelector.jsx
+++ b/glancy-site/src/components/Toolbar/ModelSelector.jsx
@@ -1,26 +1,14 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState } from 'react'
 import './Toolbar.css'
 import { useLanguage } from '../../LanguageContext.jsx'
+import useOutsideToggle from '../../hooks/useOutsideToggle.js'
 
 function ModelSelector() {
-  const [open, setOpen] = useState(false)
+  const { open, setOpen, ref: menuRef } = useOutsideToggle(false)
   const [model, setModel] = useState(
     () => localStorage.getItem('dictionaryModel') || 'model-a'
   )
-  const menuRef = useRef(null)
   const { t } = useLanguage()
-
-  useEffect(() => {
-    function handlePointerDown(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setOpen(false)
-      }
-    }
-    if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
 
   const selectModel = (value) => {
     setModel(value)

--- a/glancy-site/src/components/TopBarActions.jsx
+++ b/glancy-site/src/components/TopBarActions.jsx
@@ -1,25 +1,12 @@
-import { useState, useRef, useEffect } from 'react'
 import ModelSelector from './Toolbar'
 import { useLanguage } from '../LanguageContext.jsx'
 import { useUser } from '../context/AppContext.jsx'
+import useOutsideToggle from '../hooks/useOutsideToggle.js'
 
 function TopBarActions({ favorited = false, onToggleFavorite, canFavorite = false }) {
-  const [open, setOpen] = useState(false)
-  const menuRef = useRef(null)
+  const { open, setOpen, ref: menuRef } = useOutsideToggle(false)
   const { t } = useLanguage()
   const { user } = useUser()
-
-  useEffect(() => {
-    function handlePointerDown(e) {
-      if (menuRef.current && !menuRef.current.contains(e.target)) {
-        setOpen(false)
-      }
-    }
-    if (open) {
-      document.addEventListener('pointerdown', handlePointerDown)
-    }
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
-  }, [open])
 
   if (!user) return null
 

--- a/glancy-site/src/hooks/useOutsideToggle.js
+++ b/glancy-site/src/hooks/useOutsideToggle.js
@@ -1,0 +1,32 @@
+import { useState, useRef, useEffect } from 'react'
+
+export default function useOutsideToggle(initialOpen = false) {
+  const [open, setOpen] = useState(initialOpen)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    function handlePointerDown(e) {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+
+    function handleKeyDown(e) {
+      if (e.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+
+    if (open) {
+      document.addEventListener('pointerdown', handlePointerDown)
+      document.addEventListener('keydown', handleKeyDown)
+    }
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  return { open, setOpen, ref }
+}


### PR DESCRIPTION
### Summary
- introduce a reusable `useOutsideToggle` hook to handle outside clicks and ESC key
- refactor menu components to use the new hook and fix a minor login image bug

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68831ab3193c83329ddc3b1ec2a2bb60