### PR TITLE
[feature] centralize api facade

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -11,7 +11,7 @@ import {
   VoiceButtonLightIcon,
   VoiceButtonDarkIcon
 } from './components/Icon'
-import { useWordsApi } from './api/words.js'
+import api from './api/index.js'
 import { useLanguage } from './LanguageContext.jsx'
 import './App.css'
 import styles from './App.module.css'
@@ -39,7 +39,7 @@ function App() {
   const [fromFavorites, setFromFavorites] = useState(false)
   const { favorites, toggleFavorite } = useFavorites()
   const navigate = useNavigate()
-  const { fetchWord } = useWordsApi()
+  const { fetchWord } = api
 
   const handleToggleFavorites = () => {
     // always show favorites when invoked
@@ -83,7 +83,8 @@ function App() {
       const data = await fetchWord({
         userId: user.id,
         term: input,
-        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH'
+        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        token: user.token
       })
       setEntry(data)
       addHistory(input, user, lang === 'zh' ? 'CHINESE' : 'ENGLISH')
@@ -108,7 +109,8 @@ function App() {
       const data = await fetchWord({
         userId: user.id,
         term,
-        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH'
+        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        token: user.token
       })
       setEntry(data)
       // selecting from history should not reorder records

--- a/glancy-site/src/LocaleContext.jsx
+++ b/glancy-site/src/LocaleContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { getLocale } from './api/locale.js'
+import api from './api/index.js'
 
 const LocaleContext = createContext({
   locale: null,
@@ -14,7 +14,7 @@ export function LocaleProvider({ children }) {
 
   useEffect(() => {
     if (locale) return
-    getLocale()
+    api.getLocale()
       .then((data) => {
         setLocale(data)
         localStorage.setItem('locale', JSON.stringify(data))

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -106,7 +106,7 @@ function Login() {
   return (
     <div className={styles['auth-page']}>
       <Link to="/" className={styles['auth-close']}>×</Link>
-      <img className={styles['auth-logo']} src={icon} alt="Glancy" />
+      <BrandIcon className={styles['auth-logo']} />
       <div className={styles['auth-brand']}>Glancy</div>
       <h1 className={styles['auth-title']}>Welcome back</h1>
       {renderForm()}

--- a/glancy-site/src/api/index.js
+++ b/glancy-site/src/api/index.js
@@ -1,0 +1,16 @@
+import { createApiClient } from './client.js'
+import { createChatApi } from './chat.js'
+import { createWordsApi } from './words.js'
+import { createLocaleApi } from './locale.js'
+import { createSearchRecordsApi } from './searchRecords.js'
+
+const request = createApiClient()
+
+const api = {
+  ...createChatApi(request),
+  ...createWordsApi(request),
+  ...createLocaleApi(request),
+  ...createSearchRecordsApi(request)
+}
+
+export default api

--- a/glancy-site/src/store/historyStore.ts
+++ b/glancy-site/src/store/historyStore.ts
@@ -1,12 +1,5 @@
 import { create } from 'zustand'
-import {
-  fetchSearchRecords,
-  saveSearchRecord,
-  clearSearchRecords,
-  deleteSearchRecord,
-  favoriteSearchRecord,
-  unfavoriteSearchRecord,
-} from '../api/searchRecords.js'
+import api from '../api/index.js'
 
 import type { User } from './userStore.ts'
 
@@ -33,7 +26,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     loadHistory: async (user?: User | null) => {
       if (user) {
         try {
-          const records = await fetchSearchRecords({
+          const records = await api.fetchSearchRecords({
             userId: user.id,
             token: user.token
           })
@@ -54,7 +47,12 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     },
     addHistory: async (term: string, user?: User | null, language?: string) => {
       if (user) {
-        saveSearchRecord({ userId: user.id, token: user.token, term, language })
+        api.saveSearchRecord({
+          userId: user.id,
+          token: user.token,
+          term,
+          language
+        })
           .then((record) => {
             set((state) => ({
               recordMap: { ...state.recordMap, [term]: record.id }
@@ -70,7 +68,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     },
     clearHistory: async (user?: User | null) => {
       if (user) {
-        clearSearchRecords({ userId: user.id, token: user.token }).catch((err) => {
+        api.clearSearchRecords({ userId: user.id, token: user.token }).catch((err) => {
           console.error(err)
         })
       }
@@ -81,7 +79,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
       if (user) {
         const id = get().recordMap[term]
         if (id) {
-          deleteSearchRecord({ userId: user.id, recordId: id, token: user.token }).catch((err) => {
+          api.deleteSearchRecord({ userId: user.id, recordId: id, token: user.token }).catch((err) => {
             console.error(err)
           })
         }
@@ -97,7 +95,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     favoriteHistory: async (term: string, user?: User | null) => {
         const id = get().recordMap[term]
         if (user && id) {
-          favoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch((err) => {
+          api.favoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch((err) => {
             console.error(err)
           })
         }
@@ -105,7 +103,7 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
     unfavoriteHistory: async (term: string, user?: User | null) => {
         const id = get().recordMap[term]
         if (user && id) {
-          unfavoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch((err) => {
+          api.unfavoriteSearchRecord({ userId: user.id, token: user.token, recordId: id }).catch((err) => {
             console.error(err)
           })
         }


### PR DESCRIPTION
### Summary
- add unified API facade that reuses a single client instance
- update components and store to use the central API object
- fix an undefined icon reference in Login page

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68831ac4bc0c8332b569ca498cb46f40