### PR TITLE
[feature] handle unsupported auth options

### DIFF
--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -26,8 +26,8 @@ function Login() {
   const [account, setAccount] = useState('')
   const [password, setPassword] = useState('')
   const [method, setMethod] = useState('phone')
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+  const [showNotice, setShowNotice] = useState(false)
+  const [noticeMsg, setNoticeMsg] = useState('')
   const navigate = useNavigate()
   const { resolvedTheme } = useTheme()
   const BrandIcon =
@@ -35,7 +35,7 @@ function Login() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    setPopupMsg('')
+    setNoticeMsg('')
     try {
       const data = await api(API_PATHS.login, {
         method: 'POST',
@@ -45,8 +45,8 @@ function Login() {
       setUser(data)
       navigate('/')
     } catch (err) {
-      setPopupMsg(err.message)
-      setPopupOpen(true)
+      setNoticeMsg(err.message)
+      setShowNotice(true)
     }
   }
 
@@ -123,9 +123,14 @@ function Login() {
             <Button
               key={m}
               type="button"
-              onClick={() =>
-                formMethods.includes(m) ? setMethod(m) : alert('Not implemented')
-              }
+              onClick={() => {
+                if (formMethods.includes(m)) {
+                  setMethod(m)
+                } else {
+                  setNoticeMsg('Not implemented yet')
+                  setShowNotice(true)
+                }
+              }}
             >
               <img src={icons[m]} alt={m} />
             </Button>
@@ -142,9 +147,9 @@ function Login() {
         </div>
       </div>
       <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
+        open={showNotice}
+        message={noticeMsg}
+        onClose={() => setShowNotice(false)}
       />
     </div>
   )

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -23,8 +23,8 @@ function Register() {
   const [account, setAccount] = useState('')
   const [code, setCode] = useState('')
   const [method, setMethod] = useState('phone')
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+  const [showNotice, setShowNotice] = useState(false)
+  const [noticeMsg, setNoticeMsg] = useState('')
   const navigate = useNavigate()
   const { setUser } = useUser()
   const { resolvedTheme } = useTheme()
@@ -47,10 +47,10 @@ function Register() {
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    setPopupMsg('')
+    setNoticeMsg('')
     if (!validateAccount()) {
-      setPopupMsg('Invalid account')
-      setPopupOpen(true)
+      setNoticeMsg('Invalid account')
+      setShowNotice(true)
       return
     }
     try {
@@ -70,8 +70,8 @@ function Register() {
       setUser(loginData)
       navigate('/')
     } catch (err) {
-      setPopupMsg(err.message)
-      setPopupOpen(true)
+      setNoticeMsg(err.message)
+      setShowNotice(true)
     }
   }
 
@@ -139,9 +139,14 @@ function Register() {
             <Button
               key={m}
               type="button"
-              onClick={() =>
-                formMethods.includes(m) ? setMethod(m) : alert('Not implemented')
-              }
+              onClick={() => {
+                if (formMethods.includes(m)) {
+                  setMethod(m)
+                } else {
+                  setNoticeMsg('Not implemented yet')
+                  setShowNotice(true)
+                }
+              }}
             >
               {(() => {
                 const Icon = icons[m]
@@ -161,9 +166,9 @@ function Register() {
         </div>
       </div>
       <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
+        open={showNotice}
+        message={noticeMsg}
+        onClose={() => setShowNotice(false)}
       />
     </div>
   )


### PR DESCRIPTION
### Summary
- replace alert usage with MessagePopup
- add notice state to Login and Register

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68838f44f6dc833280b2ab6f22970d56