### PR TITLE
[fix] update loader style import

### DIFF
--- a/glancy-site/src/components/Loader.jsx
+++ b/glancy-site/src/components/Loader.jsx
@@ -1,9 +1,9 @@
-import './Loader.module.css'
+import styles from './Loader.module.css'
 
 function Loader() {
   return (
-    <div className="loader">
-      <div className="spinner" />
+    <div className={styles.loader}>
+      <div className={styles.spinner} />
     </div>
   )
 }


### PR DESCRIPTION
### Summary
- switch loader CSS import to module and use `styles.loader` and `styles.spinner`

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68838f28048c83329a3148bb9f37aebb