### PR TITLE
[feature] add unified api facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ export default defineConfig({
 
 首页会调用 `/api/users/count` 显示当前注册人数，并提供刷新按钮重新获取。
 
+## API 使用方式
+
+`ApiProvider` 会在应用初始化时创建统一的请求实例，组件中通过 `useApi` 获取：
+
+```jsx
+import { ApiProvider } from './context/ApiContext.jsx'
+import { useApi } from './hooks/useApi.js'
+
+function App() {
+  const api = useApi()
+  // example
+  useEffect(() => {
+    api.request(API_PATHS.ping)
+  }, [api])
+}
+```
+
 ## 消息弹窗组件
 
 当接口请求失败或返回结果异常时，页面会弹出临时消息提示，并可点击关闭。适用场景包括：

--- a/docs/REFACTOR_PLAN.md
+++ b/docs/REFACTOR_PLAN.md
@@ -11,11 +11,8 @@ This document tracks current cleanup efforts and future improvements.
 1. Added missing entries in `API_PATHS` so all endpoints are centralized.
 2. Updated components to reference these constants instead of literal strings.
 3. Introduced `useApi` hook providing authenticated requests.
+4. Added `ApiProvider` with a facade-based API client for global access.
 
 ## Future Work
-- Introduce a small API client or React hook to wrap `fetch` calls. This allows
-  error handling and authentication logic to be reused.
-- Apply design patterns such as the **Facade** pattern for API access and the
-  **Context** pattern for global app state.
 - Remove unused components and consolidate styles to reduce duplication.
 

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -11,7 +11,7 @@ import {
   VoiceButtonLightIcon,
   VoiceButtonDarkIcon
 } from './components/Icon'
-import api from './api/index.js'
+import { useApi } from './hooks/useApi.js'
 import { useLanguage } from './LanguageContext.jsx'
 import './App.css'
 import styles from './App.module.css'
@@ -40,7 +40,8 @@ function App() {
   const [fromFavorites, setFromFavorites] = useState(false)
   const { favorites, toggleFavorite } = useFavorites()
   const navigate = useNavigate()
-  const { fetchWord } = api
+  const api = useApi()
+  const { fetchWord } = api.words
 
   const handleToggleFavorites = () => {
     // always show favorites when invoked

--- a/glancy-site/src/Faq.jsx
+++ b/glancy-site/src/Faq.jsx
@@ -13,7 +13,7 @@ function Faq() {
   const [popupMsg, setPopupMsg] = useState('')
 
   useEffect(() => {
-    api(API_PATHS.faqs)
+    api.request(API_PATHS.faqs)
       .then((data) => setItems(data))
       .catch((err) => {
         console.error(err)

--- a/glancy-site/src/LocaleContext.jsx
+++ b/glancy-site/src/LocaleContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import api from './api/index.js'
+import { useApi } from './hooks/useApi.js'
 
 const LocaleContext = createContext({
   locale: null,
@@ -11,10 +11,11 @@ export function LocaleProvider({ children }) {
     const stored = localStorage.getItem('locale')
     return stored ? JSON.parse(stored) : null
   })
+  const api = useApi()
 
   useEffect(() => {
     if (locale) return
-    api.getLocale()
+    api.locale.getLocale()
       .then((data) => {
         setLocale(data)
         localStorage.setItem('locale', JSON.stringify(data))
@@ -22,7 +23,7 @@ export function LocaleProvider({ children }) {
       .catch((err) => {
         console.error(err)
       })
-  }, [locale])
+  }, [locale, api])
 
   return (
     <LocaleContext.Provider value={{ locale, setLocale }}>

--- a/glancy-site/src/Login.jsx
+++ b/glancy-site/src/Login.jsx
@@ -37,7 +37,7 @@ function Login() {
     e.preventDefault()
     setPopupMsg('')
     try {
-      const data = await api(API_PATHS.login, {
+      const data = await api.request(API_PATHS.login, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ account, password, method })

--- a/glancy-site/src/Preferences.jsx
+++ b/glancy-site/src/Preferences.jsx
@@ -27,7 +27,7 @@ function Preferences() {
 
   useEffect(() => {
     if (!user) return
-    api(`${API_PATHS.preferences}/user/${user.id}`)
+    api.request(`${API_PATHS.preferences}/user/${user.id}`)
       .then((data) => {
         const sl = data.systemLanguage || 'auto'
         const tl = data.searchLanguage || 'ENGLISH'
@@ -50,7 +50,7 @@ function Preferences() {
   const handleSave = async (e) => {
     e.preventDefault()
     if (!user) return
-    await api(`${API_PATHS.preferences}/user/${user.id}`, {
+    await api.request(`${API_PATHS.preferences}/user/${user.id}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -29,7 +29,7 @@ function Profile({ onCancel }) {
   })
 
   useEffect(() => {
-    api(API_PATHS.profile)
+    api.request(API_PATHS.profile)
       .then((data) => {
         setUsername(data.username)
         setEmail(data.email)
@@ -60,7 +60,7 @@ function Profile({ onCancel }) {
     if (avatar) {
       formData.append('avatar', avatar)
     }
-    await api(API_PATHS.profile, {
+    await api.request(API_PATHS.profile, {
       method: 'POST',
       body: formData
     })

--- a/glancy-site/src/Register.jsx
+++ b/glancy-site/src/Register.jsx
@@ -54,7 +54,7 @@ function Register() {
       return
     }
     try {
-      await api(API_PATHS.register, {
+      await api.request(API_PATHS.register, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -62,7 +62,7 @@ function Register() {
           code
         })
       })
-      const loginData = await api(API_PATHS.login, {
+      const loginData = await api.request(API_PATHS.login, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ account, method, password: code })

--- a/glancy-site/src/api/chat.js
+++ b/glancy-site/src/api/chat.js
@@ -16,6 +16,5 @@ export function createChatApi(request = apiRequest) {
 export const { sendChatMessage } = createChatApi()
 
 export function useChatApi() {
-  const api = useApi()
-  return createChatApi(api)
+  return useApi().chat
 }

--- a/glancy-site/src/api/index.js
+++ b/glancy-site/src/api/index.js
@@ -4,13 +4,16 @@ import { createWordsApi } from './words.js'
 import { createLocaleApi } from './locale.js'
 import { createSearchRecordsApi } from './searchRecords.js'
 
-const request = createApiClient()
-
-const api = {
-  ...createChatApi(request),
-  ...createWordsApi(request),
-  ...createLocaleApi(request),
-  ...createSearchRecordsApi(request)
+export function createApi(config) {
+  const request = createApiClient(config)
+  return {
+    request,
+    chat: createChatApi(request),
+    words: createWordsApi(request),
+    locale: createLocaleApi(request),
+    searchRecords: createSearchRecordsApi(request)
+  }
 }
 
+const api = createApi()
 export default api

--- a/glancy-site/src/api/locale.js
+++ b/glancy-site/src/api/locale.js
@@ -10,6 +10,5 @@ export function createLocaleApi(request = apiRequest) {
 export const { getLocale } = createLocaleApi()
 
 export function useLocaleApi() {
-  const api = useApi()
-  return createLocaleApi(api)
+  return useApi().locale
 }

--- a/glancy-site/src/api/searchRecords.js
+++ b/glancy-site/src/api/searchRecords.js
@@ -66,6 +66,5 @@ export const {
 } = createSearchRecordsApi()
 
 export function useSearchRecordsApi() {
-  const api = useApi()
-  return createSearchRecordsApi(api)
+  return useApi().searchRecords
 }

--- a/glancy-site/src/api/words.js
+++ b/glancy-site/src/api/words.js
@@ -29,6 +29,5 @@ export function createWordsApi(request = apiRequest) {
 export const { fetchWord, fetchWordAudio } = createWordsApi()
 
 export function useWordsApi() {
-  const api = useApi()
-  return createWordsApi(api)
+  return useApi().words
 }

--- a/glancy-site/src/context/ApiContext.jsx
+++ b/glancy-site/src/context/ApiContext.jsx
@@ -1,0 +1,15 @@
+import { createContext, useContext, useMemo } from 'react'
+import { useUser } from './AppContext.jsx'
+import { createApi } from '../api/index.js'
+
+const ApiContext = createContext(createApi())
+
+export function ApiProvider({ children }) {
+  const { user } = useUser()
+  const token = user?.token
+  const api = useMemo(() => createApi({ token }), [token])
+  return <ApiContext.Provider value={api}>{children}</ApiContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useApiContext = () => useContext(ApiContext)

--- a/glancy-site/src/hooks/useApi.js
+++ b/glancy-site/src/hooks/useApi.js
@@ -1,16 +1,5 @@
-import { useMemo } from 'react'
-import { useUser } from '../context/AppContext.jsx'
-import { apiRequest } from '../api/client.js'
+import { useApiContext } from '../context/ApiContext.jsx'
 
 export function useApi() {
-  const { user } = useUser()
-  const token = user?.token
-
-  return useMemo(() => {
-    return (url, options = {}) => {
-      const { token: optToken, ...rest } = options
-      const finalToken = optToken ?? token
-      return apiRequest(url, { ...rest, token: finalToken })
-    }
-  }, [token])
+  return useApiContext()
 }

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -11,6 +11,7 @@ const Register = lazy(() => import('./Register.jsx'))
 import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 import { AppProvider } from './context/AppContext.jsx'
+import { ApiProvider } from './context/ApiContext.jsx'
 
 function updateVh() {
   document.documentElement.style.setProperty('--vh', `${window.innerHeight}px`)
@@ -22,9 +23,10 @@ window.addEventListener('resize', updateVh)
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <AppProvider>
-      <LanguageProvider>
-        <ThemeProvider>
-          <BrowserRouter>
+      <ApiProvider>
+        <LanguageProvider>
+          <ThemeProvider>
+            <BrowserRouter>
             <ErrorBoundary>
               <Suspense fallback={<Loader />}>
                 <Routes>
@@ -34,9 +36,10 @@ createRoot(document.getElementById('root')).render(
                 </Routes>
               </Suspense>
             </ErrorBoundary>
-          </BrowserRouter>
-        </ThemeProvider>
-      </LanguageProvider>
+            </BrowserRouter>
+          </ThemeProvider>
+        </LanguageProvider>
+      </ApiProvider>
     </AppProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
### Summary
- create ApiProvider and unify request facade
- expose API via React context and update components
- document new API usage

### Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68838f3ac8b48332bd03cba2727fd248