### PR TITLE
[fix] ensure content centers in main area

### DIFF
--- a/glancy-site/src/components/Layout.module.css
+++ b/glancy-site/src/components/Layout.module.css
@@ -22,6 +22,8 @@
 .main-middle {
   flex: 1;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .main-bottom {


### PR DESCRIPTION
### Summary
- keep `main-middle` as flex container so internal components stretch to full space

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688395fa81cc83328d6f9948131617d9