### PR TITLE
[fix] support chinese query

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -13,6 +13,7 @@ import {
 } from './components/Icon'
 import { useApi } from './hooks/useApi.js'
 import { useLanguage } from './LanguageContext.jsx'
+import { detectWordLanguage } from './utils.js'
 import './App.css'
 import styles from './App.module.css'
 import Layout from './components/Layout.jsx'
@@ -82,13 +83,14 @@ function App() {
     setText('')
     setLoading(true)
     try {
+      const detectedLang = detectWordLanguage(input)
       const data = await fetchWord({
         term: input,
-        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        language: detectedLang,
         token: user.token
       })
       setEntry(data)
-      addHistory(input)
+      addHistory(input, user, detectedLang)
     } catch (err) {
       setPopupMsg(err.message)
       setPopupOpen(true)
@@ -107,9 +109,10 @@ function App() {
     setShowHistory(false)
     setLoading(true)
     try {
+      const detectedLang = detectWordLanguage(term)
       const data = await fetchWord({
         term,
-        language: lang === 'zh' ? 'CHINESE' : 'ENGLISH',
+        language: detectedLang,
         token: user.token
       })
       setEntry(data)

--- a/glancy-site/src/utils.js
+++ b/glancy-site/src/utils.js
@@ -42,3 +42,7 @@ export function useIsMobile(maxWidth = 600) {
 
   return isMobile
 }
+
+export function detectWordLanguage(text) {
+  return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'
+}


### PR DESCRIPTION
### Summary
- detect word language before querying the dictionary
- capture CHINESE vs ENGLISH to send proper API params

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68878754a7f48332b97b8764da5ef1bb