### PR TITLE
[fix] include userId in words api

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -85,6 +85,7 @@ function App() {
     try {
       const detectedLang = detectWordLanguage(input)
       const data = await fetchWord({
+        userId: user.id,
         term: input,
         language: detectedLang,
         token: user.token
@@ -111,6 +112,7 @@ function App() {
     try {
       const detectedLang = detectWordLanguage(term)
       const data = await fetchWord({
+        userId: user.id,
         term,
         language: detectedLang,
         token: user.token

--- a/glancy-site/src/api/words.js
+++ b/glancy-site/src/api/words.js
@@ -5,18 +5,19 @@ import { useApi } from '../hooks/useApi.js'
 /**
  * Query a word definition
  * @param {Object} opts
+ * @param {string} opts.userId user identifier
  * @param {string} opts.term word to search
  * @param {string} opts.language CHINESE or ENGLISH
  * @param {string} [opts.token] user token for auth header
  */
 export function createWordsApi(request = apiRequest) {
-  const fetchWord = async ({ term, language, token }) => {
-    const params = new URLSearchParams({ term, language })
+  const fetchWord = async ({ userId, term, language, token }) => {
+    const params = new URLSearchParams({ userId, term, language })
     return request(`${API_PATHS.words}?${params.toString()}`, { token })
   }
 
-  const fetchWordAudio = async ({ term, language }) => {
-    const params = new URLSearchParams({ term, language })
+  const fetchWordAudio = async ({ userId, term, language }) => {
+    const params = new URLSearchParams({ userId, term, language })
     const resp = await request(`${API_PATHS.words}/audio?${params.toString()}`)
     return resp.blob()
   }


### PR DESCRIPTION
### Summary
- add `userId` to `fetchWord` and `fetchWordAudio`
- update `App` component to send the user id

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68878cb3cef48332a5b72d6baed8fc66