### PR TITLE
[fix] search history update

### DIFF
--- a/glancy-site/src/store/historyStore.ts
+++ b/glancy-site/src/store/historyStore.ts
@@ -36,8 +36,13 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
           records.forEach((r) => {
             if (r.id) map[r.term] = r.id
           })
-          localStorage.setItem(STORAGE_KEY, JSON.stringify(terms))
-          set({ history: terms, recordMap: map })
+          const existing = get().history
+          const combined = Array.from(new Set([...terms, ...existing]))
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(combined))
+          set((state) => ({
+            history: combined,
+            recordMap: { ...state.recordMap, ...map }
+          }))
         } catch {
           // fallback to local storage
         }


### PR DESCRIPTION
### Summary
- prevent loadHistory from overwriting new search records by merging existing history

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6887a3a511c483329e09f9def5a82bc3