### PR TITLE
[feature] refine user menu layout

### DIFF
--- a/glancy-site/src/components/Header/Header.module.css
+++ b/glancy-site/src/components/Header/Header.module.css
@@ -73,6 +73,23 @@
   margin-bottom: 0.5rem;
 }
 
+.user-menu .menu-footer {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid #ccc;
+  display: flex;
+  align-items: center;
+}
+.user-menu .menu-footer .avatar {
+  width: 24px;
+  height: 24px;
+  margin-right: 0.5rem;
+}
+.user-menu .menu-footer .username {
+  margin-left: 0.5rem;
+  font-weight: 500;
+}
+
 .user-menu .avatar {
   width: 32px;
   height: 32px;
@@ -109,6 +126,14 @@
   align-items: center;
   padding: 0.25rem 0;
   cursor: pointer;
+}
+
+.user-menu li:hover {
+  background-color: rgb(0 0 0 / 5%);
+}
+
+:root[data-theme='dark'] .user-menu li:hover {
+  background-color: rgb(255 255 255 / 10%);
 }
 
 .user-menu li .icon {

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -12,6 +12,7 @@ function UserMenu({ size = 24, showName = false }) {
   const { clearHistory } = useHistory()
   const { t } = useLanguage()
   const username = user?.username || ''
+  const email = user?.email || ''
   const isPro =
     user?.member || user?.isPro || (user?.plan && user.plan !== 'free')
 
@@ -58,6 +59,7 @@ function UserMenu({ size = 24, showName = false }) {
               t={t}
               isPro={isPro}
               username={username}
+              email={email}
               openProfile={openProfile}
               openSettings={openSettings}
               openShortcuts={openShortcuts}

--- a/glancy-site/src/components/Header/UserMenuDropdown.jsx
+++ b/glancy-site/src/components/Header/UserMenuDropdown.jsx
@@ -8,6 +8,7 @@ function UserMenuDropdown({
   t,
   isPro,
   username,
+  email,
   openProfile,
   openSettings,
   openShortcuts,
@@ -21,19 +22,18 @@ function UserMenuDropdown({
       <div className={styles['menu-header']}>
         <div className={styles.avatar}>
           <Avatar width={32} height={32} />
-          {isPro && <ProTag small />}
         </div>
-        <div className={styles.username}>{username}</div>
+        <div className={styles.email}>{email}</div>
       </div>
       <ul>
         {!isPro && (
           <li onClick={() => openUpgrade()}>
-            <span className={styles.icon}>💳</span>
+            <span className={styles.icon}>🛡️</span>
             {t.upgrade}
           </li>
         )}
         <li onClick={openProfile}>
-          <span className={styles.icon}>👤</span>
+          <span className={styles.icon}>🎚️</span>
           {t.profile}
         </li>
         <li onClick={openSettings}>
@@ -41,7 +41,7 @@ function UserMenuDropdown({
           {t.settings}
         </li>
         <li onClick={openShortcuts}>
-          <span className={styles.icon}>⌨️</span>
+          <span className={styles.icon}>⌘</span>
           {t.shortcuts}
         </li>
       </ul>
@@ -57,10 +57,11 @@ function UserMenuDropdown({
             className={styles['menu-btn']}
           >
             {t.help}
+            <span className={styles.arrow}>›</span>
           </button>
         </li>
         <li>
-          <span className={styles.icon}>🔑</span>
+          <span className={styles.icon}>🚪</span>
           <button
             type="button"
             onClick={() => {
@@ -73,6 +74,13 @@ function UserMenuDropdown({
           </button>
         </li>
       </ul>
+      <div className={styles['menu-footer']}>
+        <div className={styles.avatar}>
+          <Avatar width={24} height={24} />
+          {isPro && <ProTag small />}
+        </div>
+        <div className={styles.username}>{username}</div>
+      </div>
     </div>
   )
 }

--- a/glancy-site/src/i18n/en.js
+++ b/glancy-site/src/i18n/en.js
@@ -90,7 +90,7 @@ export default {
     changeAvatar: 'Change Avatar',
     guest: 'Guest',
     upgrade: 'Upgrade',
-    profile: 'Profile',
+    profile: 'Customize Glancy',
     settings: 'Settings',
     shortcuts: 'Shortcuts',
     help: 'Help',

--- a/glancy-site/src/i18n/zh.js
+++ b/glancy-site/src/i18n/zh.js
@@ -90,7 +90,7 @@ export default {
     changeAvatar: '更换头像',
     guest: '游客',
     upgrade: '升级',
-    profile: '个人资料',
+    profile: '自定义 Glancy',
     settings: '设置',
     shortcuts: '快捷键',
     help: '帮助',


### PR DESCRIPTION
### Summary
- restyle dropdown menu hover and layout
- show email in dropdown and rename profile option

### Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887a9259fc08332a517d1b1fbc743f3