### PR TITLE
[fix] align sidebar user menu width

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.module.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.module.css
@@ -26,13 +26,13 @@
 }
 
 /* adapt header components used inside sidebar */
-.sidebar-user .header-section {
+.sidebar-user :global(.header-section) {
   display: block;
   margin-right: 0;
   width: 100%;
 }
 
-.sidebar-user .user-menu button.with-name {
+.sidebar-user :global(.user-menu) button.with-name {
   width: 100%;
   justify-content: flex-start;
   padding: 8px 0;
@@ -40,11 +40,12 @@
 }
 
 /* dropdown style inside sidebar */
-.sidebar-user .user-menu {
+.sidebar-user :global(.user-menu) {
   position: relative;
+  width: 100%;
 }
 
-.sidebar-user .user-menu .menu {
+.sidebar-user :global(.user-menu .menu) {
   inset: auto 0 calc(100% + 0.5rem);
   width: 100%;
   background: var(--sidebar-bg);


### PR DESCRIPTION
### Summary
- ensure sidebar user menu uses `:global` selectors so the dropdown width matches

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887b539547083329df58b89cfc0f4b7