### PR TITLE
[fix] allow global pseudo class

### DIFF
--- a/glancy-site/stylelint.config.cjs
+++ b/glancy-site/stylelint.config.cjs
@@ -1,3 +1,11 @@
 module.exports = {
   extends: ['stylelint-config-standard'],
+  rules: {
+    'selector-pseudo-class-no-unknown': [
+      true,
+      {
+        ignorePseudoClasses: ['global'],
+      },
+    ],
+  },
 };


### PR DESCRIPTION
### Summary
- adjust stylelint to support ':global' pseudo-class used in Sidebar styles

### Testing
- `npm run lint`
- `npm run lint:css`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887b83162ec833293435c472d780f17