### PR TITLE
[fix] enable avatar upload

### DIFF
--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -28,6 +28,23 @@ function Profile({ onCancel }) {
     phone: false
   })
 
+  const handleAvatarChange = async (e) => {
+    const file = e.target.files?.[0]
+    if (!file || !currentUser) return
+    try {
+      const data = await api.users.uploadAvatar({
+        userId: currentUser.id,
+        file,
+        token: currentUser.token
+      })
+      setAvatar(data.avatar)
+    } catch (err) {
+      console.error(err)
+      setPopupMsg(t.fail)
+      setPopupOpen(true)
+    }
+  }
+
   useEffect(() => {
     api.request(API_PATHS.profile)
       .then((data) => {
@@ -82,7 +99,7 @@ function Profile({ onCancel }) {
           <span className={styles['avatar-hint']}>{t.avatarHint}</span>
           <input
             type="file"
-            onChange={(e) => setAvatar(e.target.files[0])}
+            onChange={handleAvatarChange}
             style={{ position: 'absolute', inset: 0, opacity: 0 }}
           />
         </div>

--- a/glancy-site/src/api/index.js
+++ b/glancy-site/src/api/index.js
@@ -3,6 +3,7 @@ import { createChatApi } from './chat.js'
 import { createWordsApi } from './words.js'
 import { createLocaleApi } from './locale.js'
 import { createSearchRecordsApi } from './searchRecords.js'
+import { createUsersApi } from './users.js'
 
 export function createApi(config) {
   const request = createApiClient(config)
@@ -11,7 +12,8 @@ export function createApi(config) {
     chat: createChatApi(request),
     words: createWordsApi(request),
     locale: createLocaleApi(request),
-    searchRecords: createSearchRecordsApi(request)
+    searchRecords: createSearchRecordsApi(request),
+    users: createUsersApi(request)
   }
 }
 

--- a/glancy-site/src/api/users.js
+++ b/glancy-site/src/api/users.js
@@ -1,0 +1,23 @@
+import { API_PATHS } from '../config/api.js'
+import { apiRequest } from './client.js'
+import { useApi } from '../hooks/useApi.js'
+
+export function createUsersApi(request = apiRequest) {
+  const uploadAvatar = async ({ userId, file, token }) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    return request(`${API_PATHS.users}/${userId}/avatar-file`, {
+      method: 'POST',
+      body: formData,
+      token
+    })
+  }
+
+  return { uploadAvatar }
+}
+
+export const { uploadAvatar } = createUsersApi()
+
+export function useUsersApi() {
+  return useApi().users
+}


### PR DESCRIPTION
### Summary
- add dedicated users API module for avatar uploading
- update Profile page to call uploadAvatar when selecting a file
- register the new module in the API factory

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅

------
https://chatgpt.com/codex/tasks/task_e_68885ad71ef08332a85c0e421438e8d5