### PR TITLE
[fix] update profile endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ export default defineConfig({
 
 ## 个人资料编辑
 
-`/profile` 页面通过 `GET /api/users/profile` 载入信息，提交表单时向
-`POST /api/users/profile` 上传昵称和头像。
+`/profile` 页面通过 `GET /api/profiles/user/{userId}` 载入信息，提交表单时向
+`POST /api/profiles/user/{userId}` 保存资料。
 
 ## 偏好设置
 

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -3,7 +3,6 @@ import './App.css'
 import styles from './Profile.module.css'
 import Avatar from './components/Avatar.jsx'
 import { useLanguage } from './LanguageContext.jsx'
-import { API_PATHS } from './config/api.js'
 import MessagePopup from './components/MessagePopup.jsx'
 import { useApi } from './hooks/useApi.js'
 import { useUser } from './context/AppContext.jsx'
@@ -46,40 +45,36 @@ function Profile({ onCancel }) {
   }
 
   useEffect(() => {
-    api.request(API_PATHS.profile)
+    if (!currentUser) return
+    api.profiles
+      .fetchProfile({ userId: currentUser.id, token: currentUser.token })
       .then((data) => {
-        setUsername(data.username)
-        setEmail(data.email)
-        setPhone(data.phone)
         setAge(data.age)
         setGender(data.gender)
-        setInterests(data.interests)
+        setInterests(data.interest)
         setGoal(data.goal)
-        setAvatar(data.avatar)
+        if (data.avatar) setAvatar(data.avatar)
       })
       .catch((err) => {
         console.error(err)
         setPopupMsg(t.fail)
         setPopupOpen(true)
       })
-  }, [api, t])
+  }, [api, t, currentUser])
 
   const handleSave = async (e) => {
     e.preventDefault()
-    const formData = new FormData()
-    formData.append('username', username)
-    formData.append('email', email)
-    formData.append('phone', phone)
-    formData.append('age', age)
-    formData.append('gender', gender)
-    formData.append('interests', interests)
-    formData.append('goal', goal)
-    if (avatar) {
-      formData.append('avatar', avatar)
-    }
-    await api.request(API_PATHS.profile, {
-      method: 'POST',
-      body: formData
+    if (!currentUser) return
+    await api.profiles.saveProfile({
+      userId: currentUser.id,
+      token: currentUser.token,
+      profile: {
+        age,
+        gender,
+        job: '',
+        interest: interests,
+        goal
+      }
     })
     setPopupMsg(t.updateSuccess)
     setPopupOpen(true)

--- a/glancy-site/src/api/index.js
+++ b/glancy-site/src/api/index.js
@@ -4,6 +4,7 @@ import { createWordsApi } from './words.js'
 import { createLocaleApi } from './locale.js'
 import { createSearchRecordsApi } from './searchRecords.js'
 import { createUsersApi } from './users.js'
+import { createProfilesApi } from './profiles.js'
 
 export function createApi(config) {
   const request = createApiClient(config)
@@ -13,7 +14,8 @@ export function createApi(config) {
     words: createWordsApi(request),
     locale: createLocaleApi(request),
     searchRecords: createSearchRecordsApi(request),
-    users: createUsersApi(request)
+    users: createUsersApi(request),
+    profiles: createProfilesApi(request)
   }
 }
 

--- a/glancy-site/src/api/profiles.js
+++ b/glancy-site/src/api/profiles.js
@@ -1,0 +1,24 @@
+import { API_PATHS } from '../config/api.js'
+import { apiRequest } from './client.js'
+import { useApi } from '../hooks/useApi.js'
+
+export function createProfilesApi(request = apiRequest) {
+  const fetchProfile = ({ userId, token }) =>
+    request(`${API_PATHS.profiles}/user/${userId}`, { token })
+
+  const saveProfile = ({ userId, token, profile }) =>
+    request(`${API_PATHS.profiles}/user/${userId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(profile),
+      token
+    })
+
+  return { fetchProfile, saveProfile }
+}
+
+export const { fetchProfile, saveProfile } = createProfilesApi()
+
+export function useProfilesApi() {
+  return useApi().profiles
+}

--- a/glancy-site/src/config/api.js
+++ b/glancy-site/src/config/api.js
@@ -9,7 +9,7 @@ export const API_PATHS = {
   ping: `${API_BASE}/ping`,
   locale: `${API_BASE}/locale`,
   notifications: `${API_BASE}/notifications`,
-  profile: `${API_BASE}/users/profile`,
+  profiles: `${API_BASE}/profiles`,
   preferences: `${API_BASE}/preferences`,
   contact: `${API_BASE}/contact`,
   faqs: `${API_BASE}/faqs`,


### PR DESCRIPTION
### Summary
- use `/api/profiles/user/{id}` for profile APIs
- add profiles API module
- update profile page logic

### Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68885d7255208332b47334980911e87a