### PR TITLE
[fix] update avatar preview after upload

### DIFF
--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -9,7 +9,7 @@ import { useUser } from './context/AppContext.jsx'
 
 function Profile({ onCancel }) {
   const { t } = useLanguage()
-  const { user: currentUser } = useUser()
+  const { user: currentUser, setUser } = useUser()
   const api = useApi()
   const [username, setUsername] = useState(currentUser?.username || '')
   const [email, setEmail] = useState(currentUser?.email || '')
@@ -30,6 +30,8 @@ function Profile({ onCancel }) {
   const handleAvatarChange = async (e) => {
     const file = e.target.files?.[0]
     if (!file || !currentUser) return
+    const preview = URL.createObjectURL(file)
+    setAvatar(preview)
     try {
       const data = await api.users.uploadAvatar({
         userId: currentUser.id,
@@ -37,10 +39,13 @@ function Profile({ onCancel }) {
         token: currentUser.token
       })
       setAvatar(data.avatar)
+      setUser({ ...currentUser, avatar: data.avatar })
     } catch (err) {
       console.error(err)
       setPopupMsg(t.fail)
       setPopupOpen(true)
+    } finally {
+      URL.revokeObjectURL(preview)
     }
   }
 

--- a/glancy-site/src/components/Avatar.jsx
+++ b/glancy-site/src/components/Avatar.jsx
@@ -1,12 +1,15 @@
 import { useTheme } from '../ThemeContext.jsx'
+import { useUser } from '../context/AppContext.jsx'
 import avatarLight from '../assets/default-user-avatar-light.svg'
 import avatarDark from '../assets/default-user-avatar-dark.svg'
 
 // 基于当前主题切换默认头像
-function Avatar({ alt = 'User Avatar', ...props }) {
+function Avatar({ src, alt = 'User Avatar', ...props }) {
   const { resolvedTheme } = useTheme()
-  const src = resolvedTheme === 'dark' ? avatarDark : avatarLight
-  return <img src={src} alt={alt} {...props} />
+  const { user } = useUser()
+  const defaultSrc = resolvedTheme === 'dark' ? avatarDark : avatarLight
+  const finalSrc = src || user?.avatar || defaultSrc
+  return <img src={finalSrc} alt={alt} {...props} />
 }
 
 export default Avatar

--- a/glancy-site/src/store/userStore.ts
+++ b/glancy-site/src/store/userStore.ts
@@ -4,6 +4,7 @@ import { safeJSONParse } from '../utils.js'
 export interface User {
   id: string
   token: string
+  avatar?: string
   [key: string]: unknown
 }
 


### PR DESCRIPTION
### Summary
- show uploaded avatar instantly using an object URL
- store avatar in user context and display it globally

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6888638fe4d48332a07df4311f24040d