### PR TITLE
[fix] skip cache bust for presigned urls

### DIFF
--- a/glancy-site/src/utils.js
+++ b/glancy-site/src/utils.js
@@ -47,9 +47,16 @@ export function detectWordLanguage(text) {
   return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'
 }
 
+export function isPresignedUrl(url) {
+  if (!url || !url.includes('?')) return false
+  const query = url.split('?')[1]
+  return /(?:^|&)Signature=/.test(query) || /(?:^|&)OSSAccessKeyId=/.test(query)
+}
+
 export function cacheBust(url) {
   if (!url) return url
   if (url.includes('_v=')) return url
+  if (isPresignedUrl(url)) return url
   const sep = url.includes('?') ? '&' : '?'
   return `${url}${sep}_v=${Date.now()}`
 }


### PR DESCRIPTION
### Summary
- avoid appending the `_v` parameter when the url already contains a `Signature` or `OSSAccessKeyId` query parameter

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68890dbe15a08332905390ee409332c6