### PR TITLE
[fix] refine cache bust for presigned urls

### DIFF
--- a/glancy-site/src/utils.js
+++ b/glancy-site/src/utils.js
@@ -47,9 +47,26 @@ export function detectWordLanguage(text) {
   return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'
 }
 
+const PRESIGNED_QUERY_KEYS = ['Signature', 'OSSAccessKeyId']
+
+export function isPresignedUrl(url) {
+  if (!url) return false
+  try {
+    const base =
+      typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+    const params = new URL(url, base).searchParams
+    return PRESIGNED_QUERY_KEYS.some((key) => params.has(key))
+  } catch {
+    return PRESIGNED_QUERY_KEYS.some((key) =>
+      new RegExp(`[?&]${key}=`).test(url)
+    )
+  }
+}
+
 export function cacheBust(url) {
   if (!url) return url
   if (url.includes('_v=')) return url
+  if (isPresignedUrl(url)) return url
   const sep = url.includes('?') ? '&' : '?'
   return `${url}${sep}_v=${Date.now()}`
 }


### PR DESCRIPTION
### Summary
- refine `isPresignedUrl` with `URLSearchParams`
- skip `_v` param for presigned URLs

### Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68890dbe15a08332905390ee409332c6