### PR TITLE
[fix] hide avatar on logout and polish login buttons

### DIFF
--- a/glancy-site/src/components/Header/Header.module.css
+++ b/glancy-site/src/components/Header/Header.module.css
@@ -173,6 +173,12 @@
   align-items: center;
 }
 
+.login-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .login-btn {
   display: inline-block;
   background: var(--primary-bg);
@@ -182,8 +188,9 @@
   margin: 0;
   font: inherit;
   cursor: pointer;
-  border-radius: 20px;
+  border-radius: var(--radius-lg);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .login-btn:hover {

--- a/glancy-site/src/components/Header/UserMenu.jsx
+++ b/glancy-site/src/components/Header/UserMenu.jsx
@@ -19,14 +19,14 @@ function UserMenu({ size = 24, showName = false }) {
   if (!user) {
     return (
       <div
-        className={`${styles['header-section']} ${styles['user-menu']} ${showName ? styles['with-name'] : ''}`}
+        className={`${styles['header-section']} ${styles['login-actions']} ${showName ? styles['with-name'] : ''}`}
       >
-        <Avatar width={size} height={size} />
-        {showName && (
-          <Link to="/login" className={`${styles.username} ${styles['login-btn']}`}>\
-            {t.navRegister}/{t.navLogin}
-          </Link>
-        )}
+        <Link to="/login" className={styles['login-btn']}>
+          {t.navLogin}
+        </Link>
+        <Link to="/register" className={styles['login-btn']}>
+          {t.navRegister}
+        </Link>
       </div>
     )
   }


### PR DESCRIPTION
### Summary
- when no user is logged in show only Login/Register buttons
- style login buttons with `login-actions`

### Testing
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_688b9ff2c8008332b0e6a942bbb15d35