### PR TITLE
[fix] adjust history action popover

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -54,6 +54,7 @@ function HistoryList({ onSelect }) {
                   <div className={styles['history-menu']}>
                     <button
                       type="button"
+                      title={t.favoriteAction}
                       onClick={(e) => {
                         e.stopPropagation()
                         favoriteHistory(h, user)
@@ -61,10 +62,11 @@ function HistoryList({ onSelect }) {
                         setOpenIndex(null)
                       }}
                     >
-                      <StarSolidIcon width={16} height={16} className={styles.icon} /> {t.favoriteAction}
+                      <StarSolidIcon width={16} height={16} className={styles.icon} />
                     </button>
                     <button
                       type="button"
+                      title={t.deleteAction}
                       className={styles['delete-btn']}
                       onClick={(e) => {
                         e.stopPropagation()
@@ -72,7 +74,7 @@ function HistoryList({ onSelect }) {
                         setOpenIndex(null)
                       }}
                     >
-                      <TrashIcon width={16} height={16} className={styles.icon} /> {t.deleteAction}
+                      <TrashIcon width={16} height={16} className={styles.icon} />
                     </button>
                   </div>
                 )}

--- a/glancy-site/src/components/Sidebar/Sidebar.module.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.module.css
@@ -64,6 +64,7 @@
 .history-list {
   flex: 1;
   overflow-y: auto;
+  overflow-x: visible;
 }
 
 .history-list li {
@@ -108,28 +109,35 @@
 
 .history-menu {
   position: absolute;
-  right: 0;
-  top: calc(100% + 4px);
+  top: 50%;
+  left: calc(100% + 4px);
+  transform: translateY(-50%);
+  display: flex;
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);
   border-radius: 4px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 15%);
   z-index: 100;
 }
 
 .history-menu button {
-  display: block;
-  width: 100%;
   background: none;
   border: none;
-  padding: 4px 8px;
-  text-align: left;
+  padding: 4px;
   color: inherit;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.history-menu button + button {
+  border-left: 1px solid var(--border-color);
 }
 
 .history-menu .icon {
-  margin-right: 4px;
+  margin: 0;
 }
 
 .history-menu button:hover {


### PR DESCRIPTION
### Summary
- Rework history action menu to open horizontally beside its trigger
- Allow sidebar history list to expose the menu outside the sidebar area

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68904a1a7b348332b96f03c167f9cd1c