### PR TITLE
[fix] resolve CSS lint warnings

### DIFF
--- a/glancy-site/src/components/Layout.module.css
+++ b/glancy-site/src/components/Layout.module.css
@@ -36,7 +36,7 @@
   display: flex;
   align-items: center;
   box-sizing: border-box;
-  padding: 0 20px 0 20px;
+  padding: 0 20px;
 }
 
 @media (width <= 600px) {

--- a/glancy-site/src/components/Sidebar/Sidebar.module.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.module.css
@@ -18,7 +18,7 @@
   align-items: center;
   gap: 0.5rem;
   height: var(--bar-height);
-  padding: 0 20px 0 20px;
+  padding: 0 20px;
   position: sticky;
   bottom: 0;
   background: inherit;
@@ -63,8 +63,7 @@
 
 .history-list {
   flex: 1;
-  overflow-y: auto;
-  overflow-x: visible;
+  overflow: visible auto;
 }
 
 .history-list li {


### PR DESCRIPTION
### Summary
- Remove redundant padding values in layout and sidebar styles.
- Consolidate sidebar history list overflow settings into shorthand.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68904be405808332824827c8b9e02063