### PR TITLE
[refactor] extract ICP footer component

### DIFF
--- a/glancy-site/src/App.css
+++ b/glancy-site/src/App.css
@@ -110,18 +110,6 @@
   height: 36px;
 }
 
-.icp {
-  text-align: center;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin: 8px 0;
-}
-
-.icp a {
-  color: inherit;
-  text-decoration: none;
-}
-
 @media (width <= 600px) {
   .sidebar {
     position: fixed;

--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -20,6 +20,7 @@ import Layout from './components/Layout.jsx'
 import HistoryDisplay from './components/HistoryDisplay.jsx'
 import ListItem from './components/ListItem/ListItem.jsx'
 import { useModelStore } from './store/modelStore.ts'
+import Icp from './components/Icp.jsx'
 
 function App() {
   const [text, setText] = useState('')
@@ -268,11 +269,7 @@ function App() {
           )}
         </div>
       </Layout>
-      <div className="icp">
-        <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">
-          京ICP备2025135702号-1
-        </a>
-      </div>
+      <Icp />
       <MessagePopup
         open={popupOpen}
         message={popupMsg}

--- a/glancy-site/src/AuthPage.module.css
+++ b/glancy-site/src/AuthPage.module.css
@@ -234,18 +234,6 @@
   margin: 0 4px;
 }
 
-.icp {
-  text-align: center;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin-bottom: 8px;
-}
-
-.icp a {
-  color: inherit;
-  text-decoration: none;
-}
-
 .auth-close {
   position: absolute;
   top: 20px;

--- a/glancy-site/src/components/AuthForm.jsx
+++ b/glancy-site/src/components/AuthForm.jsx
@@ -5,6 +5,7 @@ import PhoneInput from './PhoneInput.jsx'
 import { Button } from './index.js'
 import styles from '../AuthPage.module.css'
 import MessagePopup from './MessagePopup.jsx'
+import Icp from './Icp.jsx'
 import {
   GoogleIcon,
   AppleIcon,
@@ -143,11 +144,7 @@ function AuthForm({
         <div className={styles['footer-links']}>
           <a href="#">Terms of Use</a> | <a href="#">Privacy Policy</a>
         </div>
-        <div className={styles.icp}>
-          <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">
-            京ICP备2025135702号-1
-          </a>
-        </div>
+        <Icp />
       </div>
       <MessagePopup
         open={showNotice}

--- a/glancy-site/src/components/Icp.jsx
+++ b/glancy-site/src/components/Icp.jsx
@@ -1,0 +1,13 @@
+import styles from './Icp.module.css'
+
+function Icp() {
+  return (
+    <div className={styles.icp}>
+      <a href="https://beian.miit.gov.cn/" target="_blank" rel="noopener">
+        京ICP备2025135702号-1
+      </a>
+    </div>
+  )
+}
+
+export default Icp

--- a/glancy-site/src/components/Icp.module.css
+++ b/glancy-site/src/components/Icp.module.css
@@ -1,0 +1,11 @@
+.icp {
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin: 8px 0;
+}
+
+.icp a {
+  color: inherit;
+  text-decoration: none;
+}


### PR DESCRIPTION
### Summary
- abstract ICP record footer into reusable `Icp` component
- replace inline ICP markup in `App` and `AuthForm` with the new component

### Testing
- `npm ci` *(fails: The `npm ci` command can only install with an existing package-lock.json or npm-shrinkwrap.json)* ❌
- `npm install` ✅
- `npm run lint` ✅
- `npm run lint:css` *(fails: Expected "0 20px 0 20px" to be "0 20px" etc.)* ❌
- `npm run build` ✅
- `npm test` ✅

### Notes
- `npm ci` requires a lockfile which is not present in the repository.
- `npm run lint:css` reported pre-existing style issues unrelated to this change.


------
https://chatgpt.com/codex/tasks/task_e_68904bbc4ac8833294f3d470fc23fa08