### PR TITLE
[fix] align ICP footer and chatbox backgrounds

### DIFF
--- a/glancy-site/src/components/Icp.module.css
+++ b/glancy-site/src/components/Icp.module.css
@@ -2,7 +2,8 @@
   text-align: center;
   font-size: 0.75rem;
   color: var(--text-muted);
-  margin: 8px 0;
+  background: var(--app-bg);
+  padding: 8px 0;
 }
 
 .icp a {


### PR DESCRIPTION
### Summary
- ensure ICP footer shares the same background theme variable as chatbox for visual consistency

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68905607cf048332825396da78373a06