### PR TITLE
[feature] center search loading animation

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import { useTheme } from './ThemeContext.jsx'
 import translations from './translations.js'
 import DictionaryEntry from './components/DictionaryEntry.jsx'
+import RhythmLoader from './components/RhythmLoader.jsx'
 import {
   SendButtonLightIcon,
   SendButtonDarkIcon,
@@ -259,7 +260,9 @@ function App() {
           ) : showHistory ? (
             <HistoryDisplay />
           ) : loading ? (
-            '...'
+            <div className="display-content">
+              <RhythmLoader />
+            </div>
           ) : entry ? (
             <DictionaryEntry entry={entry} />
           ) : (

--- a/glancy-site/src/components/RhythmLoader.jsx
+++ b/glancy-site/src/components/RhythmLoader.jsx
@@ -1,0 +1,19 @@
+import styles from './RhythmLoader.module.css'
+
+function RhythmLoader() {
+  return (
+    <div className={styles.loader} role="status" aria-label="loading">
+      <svg className={styles.svg} viewBox="0 0 120 40">
+        <circle className={styles.dot} cx="15" cy="20" r="5" />
+        <circle className={styles.dot} cx="35" cy="20" r="5" />
+        <circle className={styles.dot} cx="55" cy="20" r="5" />
+        <rect className={styles.bar} x="70" y="10" width="10" height="20" rx="3" />
+        <rect className={styles.bar} x="90" y="10" width="10" height="20" rx="3" />
+        <rect className={styles.bar} x="110" y="10" width="10" height="20" rx="3" />
+      </svg>
+    </div>
+  )
+}
+
+export default RhythmLoader
+

--- a/glancy-site/src/components/RhythmLoader.module.css
+++ b/glancy-site/src/components/RhythmLoader.module.css
@@ -1,0 +1,71 @@
+.loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.svg {
+  width: 120px;
+  height: 40px;
+}
+
+.dot,
+.bar {
+  fill: currentcolor;
+}
+
+.dot {
+  animation: dotPulse 1.2s ease-in-out infinite;
+}
+
+.dot:nth-of-type(1) {
+  animation-delay: 0s;
+}
+
+.dot:nth-of-type(2) {
+  animation-delay: 0.2s;
+}
+
+.dot:nth-of-type(3) {
+  animation-delay: 0.4s;
+}
+
+.bar {
+  transform-origin: center bottom;
+  animation: barPulse 1.2s ease-in-out infinite;
+}
+
+.bar:nth-of-type(4) {
+  animation-delay: 0s;
+}
+
+.bar:nth-of-type(5) {
+  animation-delay: 0.2s;
+}
+
+.bar:nth-of-type(6) {
+  animation-delay: 0.4s;
+}
+
+@keyframes dotPulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes barPulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scaleY(0.4);
+  }
+  40% {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+


### PR DESCRIPTION
### Summary
- Replace text-based search loading indicator with rhythmic SVG animation centered in the display area.
- Add reusable `RhythmLoader` component for consistent loading feedback.

### Testing
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6890617a00cc8332880945335bdaf706