### PR TITLE
[fix] standardize RhythmLoader keyframe naming

### DIFF
--- a/glancy-site/src/components/RhythmLoader.module.css
+++ b/glancy-site/src/components/RhythmLoader.module.css
@@ -15,7 +15,7 @@
 }
 
 .dot {
-  animation: dotPulse 1.2s ease-in-out infinite;
+  animation: dot-pulse 1.2s ease-in-out infinite;
 }
 
 .dot:nth-of-type(1) {
@@ -32,7 +32,7 @@
 
 .bar {
   transform-origin: center bottom;
-  animation: barPulse 1.2s ease-in-out infinite;
+  animation: bar-pulse 1.2s ease-in-out infinite;
 }
 
 .bar:nth-of-type(4) {
@@ -47,22 +47,24 @@
   animation-delay: 0.4s;
 }
 
-@keyframes dotPulse {
+@keyframes dot-pulse {
   0%, 80%, 100% {
     opacity: 0.3;
     transform: translateY(0);
   }
+
   40% {
     opacity: 1;
     transform: translateY(-6px);
   }
 }
 
-@keyframes barPulse {
+@keyframes bar-pulse {
   0%, 80%, 100% {
     opacity: 0.3;
     transform: scaleY(0.4);
   }
+
   40% {
     opacity: 1;
     transform: scaleY(1);


### PR DESCRIPTION
### Summary
- use kebab-case animation and keyframe names in `RhythmLoader`
- add spacing inside keyframes to satisfy stylelint

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run lint:css` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_689063c46d688332b21de246ca1e8d32