### PR TITLE
[feature] add color management system

### DIFF
--- a/glancy-site/src/Profile.module.css
+++ b/glancy-site/src/Profile.module.css
@@ -38,7 +38,7 @@
   bottom: 0;
   height: 30%;
   background: rgb(0 0 0 / 50%);
-  color: #fff;
+  color: var(--overlay-text);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -150,7 +150,7 @@
 .tooltip .tooltip-text {
   visibility: hidden;
   background: rgb(0 0 0 / 75%);
-  color: #fff;
+  color: var(--overlay-text);
   text-align: center;
   padding: 4px 8px;
   border-radius: 4px;

--- a/glancy-site/src/components/Brand.jsx
+++ b/glancy-site/src/components/Brand.jsx
@@ -2,10 +2,12 @@ import { useLanguage } from '../LanguageContext.jsx'
 import { useTheme } from '../ThemeContext.jsx'
 import { GlancyWebLightIcon, GlancyWebDarkIcon } from './Icon'
 import { UserMenu } from './Header'
+import { useColors } from '../hooks/useColors'
 
 function Brand() {
   const { lang } = useLanguage()
   const { resolvedTheme } = useTheme()
+  const colors = useColors()
   const BrandIcon = resolvedTheme === 'dark' ? GlancyWebDarkIcon : GlancyWebLightIcon
   const text = lang === 'zh' ? '格律词典' : 'Glancy'
 
@@ -17,7 +19,7 @@ function Brand() {
     <div className="sidebar-brand">
       <div className="brand-main" onClick={handleClick}>
         <BrandIcon alt="Glancy" />
-        <span>{text}</span>
+        <span style={{ color: colors.brand }}>{text}</span>
       </div>
       <div className="mobile-user-menu">
         <UserMenu size={28} />

--- a/glancy-site/src/domain/colors.js
+++ b/glancy-site/src/domain/colors.js
@@ -1,0 +1,8 @@
+export const ColorTokens = Object.freeze({
+  APP_BG: '--app-bg',
+  APP_TEXT: '--app-color',
+  ACCENT: '--accent-color',
+  BORDER: '--border-color',
+  BRAND: '--brand-color',
+  OVERLAY_TEXT: '--overlay-text',
+})

--- a/glancy-site/src/hooks/useColors.js
+++ b/glancy-site/src/hooks/useColors.js
@@ -1,0 +1,6 @@
+import { useSyncExternalStore } from 'react'
+import { colorService } from '../services/ColorService'
+
+export function useColors() {
+  return useSyncExternalStore(colorService.subscribe, colorService.getSnapshot)
+}

--- a/glancy-site/src/services/ColorService.js
+++ b/glancy-site/src/services/ColorService.js
@@ -1,0 +1,28 @@
+import { ColorTokens } from '../domain/colors'
+
+class ColorService {
+  constructor(tokens) {
+    this.tokens = tokens
+  }
+
+  getSnapshot = () => {
+    const styles = getComputedStyle(document.documentElement)
+    return Object.fromEntries(
+      Object.entries(this.tokens).map(([key, variable]) => [
+        key.toLowerCase(),
+        styles.getPropertyValue(variable).trim(),
+      ]),
+    )
+  }
+
+  subscribe = (callback) => {
+    const observer = new MutationObserver(callback)
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    })
+    return () => observer.disconnect()
+  }
+}
+
+export const colorService = new ColorService(ColorTokens)

--- a/glancy-site/src/theme/colors.css
+++ b/glancy-site/src/theme/colors.css
@@ -22,4 +22,5 @@
   /* text scales */
   --text-primary-light: #1a1a1a;
   --text-primary-dark: #f5f5f5;
+  --overlay-text: var(--sys-bg-light);
 }


### PR DESCRIPTION
### Summary
- introduce a domain-driven color service with React hook to centralize theme-aware color tokens
- apply the service to the brand component and unify overlay text styling via a dedicated color variable

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_68906b1d478c8332aef06e08942340a8