### PR TITLE
[fix] ensure main page loads by default

### DIFF
--- a/glancy-site/src/NotFound.jsx
+++ b/glancy-site/src/NotFound.jsx
@@ -1,0 +1,15 @@
+import { useLanguage } from './LanguageContext.jsx'
+import styles from './NotFound.module.css'
+
+function NotFound() {
+  const { t } = useLanguage()
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>{t.notFoundTitle}</h1>
+      <p className={styles.message}>{t.notFoundMessage}</p>
+    </div>
+  )
+}
+
+export default NotFound
+

--- a/glancy-site/src/NotFound.module.css
+++ b/glancy-site/src/NotFound.module.css
@@ -1,0 +1,21 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: var(--vh);
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.title {
+  font-size: 2rem;
+  margin: 0;
+}
+
+.message {
+  color: var(--text-muted);
+  margin: 0;
+}
+

--- a/glancy-site/src/i18n/en.js
+++ b/glancy-site/src/i18n/en.js
@@ -119,5 +119,7 @@ export default {
     favoriteAction: 'Favorite',
     deleteAction: 'Delete',
     searchPlaceholder: 'What are we querying next?',
-    inputPlaceholder: 'Word, Phrase or Sentence'
+    inputPlaceholder: 'Word, Phrase or Sentence',
+    notFoundTitle: 'Page Not Found',
+    notFoundMessage: "We couldn't find the page you're looking for."
 }

--- a/glancy-site/src/i18n/zh.js
+++ b/glancy-site/src/i18n/zh.js
@@ -119,5 +119,7 @@ export default {
     favoriteAction: '收藏',
     deleteAction: '删除',
     searchPlaceholder: '接下来查询什么？',
-    inputPlaceholder: '单词、短语或句子'
+    inputPlaceholder: '单词、短语或句子',
+    notFoundTitle: '页面不存在',
+    notFoundMessage: '无法找到您访问的页面。'
 }

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -8,6 +8,7 @@ import Loader from './components/Loader.jsx'
 const App = lazy(() => import('./App.jsx'))
 const Login = lazy(() => import('./Login.jsx'))
 const Register = lazy(() => import('./Register.jsx'))
+const NotFound = lazy(() => import('./NotFound.jsx'))
 import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 import { AppProvider } from './context/AppContext.jsx'
@@ -41,9 +42,10 @@ createRoot(document.getElementById('root')).render(
             <ErrorBoundary>
               <Suspense fallback={<Loader />}>
                 <Routes>
+                  <Route path="/" element={<App />} />
                   <Route path="/login" element={<Login />} />
                   <Route path="/register" element={<Register />} />
-                  <Route path="*" element={<App />} />
+                  <Route path="*" element={<NotFound />} />
                 </Routes>
               </Suspense>
             </ErrorBoundary>


### PR DESCRIPTION
### Summary
- route `/` directly to the main `App` component and show a not-found screen for unmatched paths
- add a simple, localized `NotFound` page with styling to keep experience consistent

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68906f52344c83328a70aff260238170