### PR TITLE
[refactor] centralize message popup handling

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
-import MessagePopup from './components/MessagePopup.jsx'
 import { useHistory, useUser, useFavorites } from './context/AppContext.jsx'
 import { useNavigate } from 'react-router-dom'
 import { useTheme } from './ThemeContext.jsx'
+import { useMessageService } from './context/MessageContext.jsx'
 import translations from './translations.js'
 import DictionaryEntry from './components/DictionaryEntry.jsx'
 import RhythmLoader from './components/RhythmLoader.jsx'
@@ -29,8 +29,7 @@ function App() {
   const { t, lang, setLang } = useLanguage()
   const placeholder = t.searchPlaceholder
   const [loading, setLoading] = useState(false)
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+    const messageService = useMessageService()
   const { user } = useUser()
   const { loadHistory, addHistory, unfavoriteHistory } = useHistory()
   const { theme, resolvedTheme, setTheme } = useTheme()
@@ -98,8 +97,7 @@ function App() {
       setEntry(data)
       addHistory(input, user, detectedLang)
     } catch (err) {
-      setPopupMsg(err.message)
-      setPopupOpen(true)
+        messageService.show(err.message)
     } finally {
       setLoading(false)
     }
@@ -126,8 +124,7 @@ function App() {
       setEntry(data)
       // selecting from history should not reorder records
     } catch (err) {
-      setPopupMsg(err.message)
-      setPopupOpen(true)
+        messageService.show(err.message)
     } finally {
       setLoading(false)
     }
@@ -273,11 +270,6 @@ function App() {
         </div>
       </Layout>
       <Icp />
-      <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
-      />
     </>
   )
 }

--- a/glancy-site/src/Faq.jsx
+++ b/glancy-site/src/Faq.jsx
@@ -3,24 +3,22 @@ import './App.css'
 import { useLanguage } from './LanguageContext.jsx'
 import { API_PATHS } from './config/api.js'
 import { useApi } from './hooks/useApi.js'
-import MessagePopup from './components/MessagePopup.jsx'
+import { useMessageService } from './context/MessageContext.jsx'
 
 function Faq() {
   const { t } = useLanguage()
   const [items, setItems] = useState([])
   const api = useApi()
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+    const messageService = useMessageService()
 
   useEffect(() => {
     api.request(API_PATHS.faqs)
       .then((data) => setItems(data))
-      .catch((err) => {
-        console.error(err)
-        setPopupMsg(t.fail)
-        setPopupOpen(true)
-      })
-  }, [api, t])
+        .catch((err) => {
+          console.error(err)
+          messageService.show(t.fail)
+        })
+  }, [api, t, messageService])
 
   return (
     <div className="app">
@@ -33,11 +31,6 @@ function Faq() {
           </li>
         ))}
       </ul>
-      <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
-      />
     </div>
   )
 }

--- a/glancy-site/src/Preferences.jsx
+++ b/glancy-site/src/Preferences.jsx
@@ -5,8 +5,8 @@ import { useLanguage } from './LanguageContext.jsx'
 import { useTheme } from './ThemeContext.jsx'
 import { useUser } from './context/AppContext.jsx'
 import { API_PATHS } from './config/api.js'
-import MessagePopup from './components/MessagePopup.jsx'
 import { useApi } from './hooks/useApi.js'
+import { useMessageService } from './context/MessageContext.jsx'
 import { useModelStore } from './store/modelStore.ts'
 
 function Preferences() {
@@ -23,8 +23,7 @@ function Preferences() {
     localStorage.getItem('targetLang') || 'ENGLISH'
   )
   const [defaultModel, setDefaultModel] = useState(model)
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+    const messageService = useMessageService()
 
   useEffect(() => {
     api.llm
@@ -48,12 +47,11 @@ function Preferences() {
         localStorage.setItem('targetLang', tl)
         setTheme(data.theme || 'system')
       })
-      .catch((err) => {
-        console.error(err)
-        setPopupMsg(t.fail)
-        setPopupOpen(true)
-      })
-  }, [setTheme, t, user, api, model, setModel])
+        .catch((err) => {
+          console.error(err)
+          messageService.show(t.fail)
+        })
+  }, [setTheme, t, user, api, model, setModel, messageService])
 
   const handleSave = async (e) => {
     e.preventDefault()
@@ -71,8 +69,7 @@ function Preferences() {
     localStorage.setItem('sourceLang', sourceLang)
     localStorage.setItem('targetLang', targetLang)
     setModel(defaultModel)
-    setPopupMsg(t.saveSuccess)
-    setPopupOpen(true)
+      messageService.show(t.saveSuccess)
   }
 
   return (
@@ -123,11 +120,6 @@ function Preferences() {
         </div>
         <button type="submit">{t.saveButton}</button>
       </form>
-      <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
-      />
     </div>
   )
 }

--- a/glancy-site/src/Profile.jsx
+++ b/glancy-site/src/Profile.jsx
@@ -3,11 +3,11 @@ import './App.css'
 import styles from './Profile.module.css'
 import Avatar from './components/Avatar.jsx'
 import { useLanguage } from './LanguageContext.jsx'
-import MessagePopup from './components/MessagePopup.jsx'
 import AgeStepper from './components/AgeStepper/AgeStepper.jsx'
 import GenderSelect from './components/GenderSelect/GenderSelect.jsx'
 import { useApi } from './hooks/useApi.js'
 import { useUser } from './context/AppContext.jsx'
+import { useMessageService } from './context/MessageContext.jsx'
 import { cacheBust } from './utils.js'
 import { CakeIcon, UserIcon, StarIcon, TargetIcon } from './components/Icon'
 
@@ -23,8 +23,7 @@ function Profile({ onCancel }) {
   const [interests, setInterests] = useState('')
   const [goal, setGoal] = useState('')
   const [avatar, setAvatar] = useState('')
-  const [popupOpen, setPopupOpen] = useState(false)
-  const [popupMsg, setPopupMsg] = useState('')
+  const messageService = useMessageService()
   const [editable, setEditable] = useState({
     username: false,
     email: false,
@@ -47,8 +46,7 @@ function Profile({ onCancel }) {
       setUser({ ...currentUser, avatar: url })
     } catch (err) {
       console.error(err)
-      setPopupMsg(t.fail)
-      setPopupOpen(true)
+      messageService.show(t.fail)
     } finally {
       URL.revokeObjectURL(preview)
     }
@@ -70,10 +68,9 @@ function Profile({ onCancel }) {
       })
       .catch((err) => {
         console.error(err)
-        setPopupMsg(t.fail)
-        setPopupOpen(true)
+        messageService.show(t.fail)
       })
-  }, [api, t, currentUser])
+  }, [api, t, currentUser, messageService])
 
   const handleSave = async (e) => {
     e.preventDefault()
@@ -89,8 +86,7 @@ function Profile({ onCancel }) {
         goal
       }
     })
-    setPopupMsg(t.updateSuccess)
-    setPopupOpen(true)
+    messageService.show(t.updateSuccess)
   }
 
 
@@ -215,14 +211,9 @@ function Profile({ onCancel }) {
             {t.cancelButton || '取消'}
           </button>
         </div>
-      </form>
-      <MessagePopup
-        open={popupOpen}
-        message={popupMsg}
-        onClose={() => setPopupOpen(false)}
-      />
-    </div>
-  )
-}
+        </form>
+      </div>
+    )
+  }
 
-export default Profile
+  export default Profile

--- a/glancy-site/src/components/AuthForm.jsx
+++ b/glancy-site/src/components/AuthForm.jsx
@@ -4,7 +4,6 @@ import CodeButton from './CodeButton.jsx'
 import PhoneInput from './PhoneInput.jsx'
 import { Button } from './index.js'
 import styles from '../AuthPage.module.css'
-import MessagePopup from './MessagePopup.jsx'
 import Icp from './Icp.jsx'
 import {
   GoogleIcon,
@@ -17,6 +16,7 @@ import {
   GlancyWebDarkIcon
 } from './Icon'
 import { useTheme } from '../ThemeContext.jsx'
+import { useMessageService } from '../context/MessageContext.jsx'
 
 const defaultIcons = {
   username: UserIcon,
@@ -43,8 +43,7 @@ function AuthForm({
   const [account, setAccount] = useState('')
   const [password, setPassword] = useState('')
   const [method, setMethod] = useState(formMethods[0])
-  const [showNotice, setShowNotice] = useState(false)
-  const [noticeMsg, setNoticeMsg] = useState('')
+  const messageService = useMessageService()
   const { resolvedTheme } = useTheme()
   const BrandIcon =
     resolvedTheme === 'dark' ? GlancyWebDarkIcon : GlancyWebLightIcon
@@ -53,17 +52,14 @@ function AuthForm({
 
   const handleSubmit = async (e) => {
     e.preventDefault()
-    setNoticeMsg('')
     if (!validateAccount(account, method)) {
-      setNoticeMsg('Invalid account')
-      setShowNotice(true)
+      messageService.show('Invalid account')
       return
     }
     try {
       await onSubmit({ account, password, method })
     } catch (err) {
-      setNoticeMsg(err.message)
-      setShowNotice(true)
+      messageService.show(err.message)
     }
   }
 
@@ -123,36 +119,30 @@ function AuthForm({
           .map((m) => {
             const Icon = icons[m]
             return (
-              <Button
-                key={m}
-                type="button"
-                onClick={() => {
-                  if (formMethods.includes(m)) {
-                    setMethod(m)
-                  } else {
-                    setNoticeMsg('Not implemented yet')
-                    setShowNotice(true)
-                  }
-                }}
-              >
-                <Icon alt={m} />
-              </Button>
-            )
-          })}
-      </div>
-      <div className={styles['auth-footer']}>
-        <div className={styles['footer-links']}>
-          <a href="#">Terms of Use</a> | <a href="#">Privacy Policy</a>
+                <Button
+                  key={m}
+                  type="button"
+                  onClick={() => {
+                    if (formMethods.includes(m)) {
+                      setMethod(m)
+                    } else {
+                      messageService.show('Not implemented yet')
+                    }
+                  }}
+                >
+                  <Icon alt={m} />
+                </Button>
+              )
+            })}
         </div>
-        <Icp />
+        <div className={styles['auth-footer']}>
+          <div className={styles['footer-links']}>
+            <a href="#">Terms of Use</a> | <a href="#">Privacy Policy</a>
+          </div>
+          <Icp />
+        </div>
       </div>
-      <MessagePopup
-        open={showNotice}
-        message={noticeMsg}
-        onClose={() => setShowNotice(false)}
-      />
-    </div>
-  )
-}
+    )
+  }
 
-export default AuthForm
+  export default AuthForm

--- a/glancy-site/src/components/MessagePopup.module.css
+++ b/glancy-site/src/components/MessagePopup.module.css
@@ -15,9 +15,10 @@
 .popup {
   background: var(--app-bg);
   color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
-  max-width: 300px;
+  padding: var(--space-4);
+  border-radius: 12px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 20%);
+  max-width: 320px;
   width: 90%;
   text-align: center;
 }

--- a/glancy-site/src/context/MessageContext.jsx
+++ b/glancy-site/src/context/MessageContext.jsx
@@ -1,0 +1,22 @@
+import { createContext, useContext, useMemo } from 'react'
+import { useSyncExternalStore } from 'react'
+import MessagePopup from '../components/MessagePopup.jsx'
+import { createMessageService } from '../services/MessageService.js'
+
+const MessageContext = createContext(createMessageService())
+
+export function MessageProvider({ service = createMessageService(), children }) {
+  const store = useMemo(() => service, [service])
+  const message = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  const handleClose = () => store.clear()
+
+  return (
+    <MessageContext.Provider value={store}>
+      {children}
+      <MessagePopup open={!!message} message={message} onClose={handleClose} />
+    </MessageContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useMessageService = () => useContext(MessageContext)

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -13,6 +13,7 @@ import { LanguageProvider } from './LanguageContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 import { AppProvider } from './context/AppContext.jsx'
 import { ApiProvider } from './context/ApiContext.jsx'
+import { MessageProvider } from './context/MessageContext.jsx'
 
 // eslint-disable-next-line react-refresh/only-export-components
 function ViewportHeightUpdater() {
@@ -34,26 +35,28 @@ function ViewportHeightUpdater() {
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <ViewportHeightUpdater />
-    <AppProvider>
-      <ApiProvider>
-        <LanguageProvider>
-          <ThemeProvider>
-            <BrowserRouter>
-            <ErrorBoundary>
-              <Suspense fallback={<Loader />}>
-                <Routes>
-                  <Route path="/" element={<App />} />
-                  <Route path="/login" element={<Login />} />
-                  <Route path="/register" element={<Register />} />
-                  <Route path="*" element={<NotFound />} />
-                </Routes>
-              </Suspense>
-            </ErrorBoundary>
-            </BrowserRouter>
-          </ThemeProvider>
-        </LanguageProvider>
-      </ApiProvider>
-    </AppProvider>
+      <AppProvider>
+        <ApiProvider>
+          <LanguageProvider>
+            <ThemeProvider>
+              <MessageProvider>
+                <BrowserRouter>
+                <ErrorBoundary>
+                  <Suspense fallback={<Loader />}> 
+                    <Routes>
+                      <Route path="/" element={<App />} />
+                      <Route path="/login" element={<Login />} />
+                      <Route path="/register" element={<Register />} />
+                      <Route path="*" element={<NotFound />} />
+                    </Routes>
+                  </Suspense>
+                </ErrorBoundary>
+                </BrowserRouter>
+              </MessageProvider>
+            </ThemeProvider>
+          </LanguageProvider>
+        </ApiProvider>
+      </AppProvider>
   </StrictMode>,
 )
 

--- a/glancy-site/src/services/MessageService.js
+++ b/glancy-site/src/services/MessageService.js
@@ -1,0 +1,33 @@
+class MessageService {
+  constructor() {
+    this.current = ''
+    this.listeners = new Set()
+  }
+
+  getSnapshot = () => this.current
+
+  subscribe = (callback) => {
+    this.listeners.add(callback)
+    return () => this.listeners.delete(callback)
+  }
+
+  show = (msg) => {
+    this.current = msg
+    this._emit()
+  }
+
+  clear = () => {
+    this.current = ''
+    this._emit()
+  }
+
+  _emit = () => {
+    for (const cb of this.listeners) {
+      cb()
+    }
+  }
+}
+
+export function createMessageService() {
+  return new MessageService()
+}


### PR DESCRIPTION
### Summary
- introduce observable MessageService with provider-based dependency injection
- refactor pages to publish errors through the shared message service and refine popup styling

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68907340cae483329052af1190eceeb5