### PR TITLE
[fix] stabilize message service to restore search page

### DIFF
--- a/glancy-site/src/context/MessageContext.jsx
+++ b/glancy-site/src/context/MessageContext.jsx
@@ -1,13 +1,18 @@
-import { createContext, useContext, useMemo } from 'react'
+import { createContext, useContext, useRef } from 'react'
 import { useSyncExternalStore } from 'react'
 import MessagePopup from '../components/MessagePopup.jsx'
 import { createMessageService } from '../services/MessageService.js'
 
 const MessageContext = createContext(createMessageService())
 
-export function MessageProvider({ service = createMessageService(), children }) {
-  const store = useMemo(() => service, [service])
-  const message = useSyncExternalStore(store.subscribe, store.getSnapshot)
+export function MessageProvider({ service, children }) {
+  const storeRef = useRef(service || createMessageService())
+  const store = storeRef.current
+  const message = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot
+  )
   const handleClose = () => store.clear()
 
   return (


### PR DESCRIPTION
### Summary
- ensure message service uses a single instance and server snapshot to avoid runtime crashes

### Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689075da7f6c833296c7af42d597208e