### PR TITLE
[feature] add event bus for message service

### DIFF
--- a/glancy-site/src/context/MessageContext.jsx
+++ b/glancy-site/src/context/MessageContext.jsx
@@ -5,8 +5,8 @@ import { createMessageService } from '../services/MessageService.js'
 
 const MessageContext = createContext(createMessageService())
 
-export function MessageProvider({ service, children }) {
-  const storeRef = useRef(service || createMessageService())
+export function MessageProvider({ service, bus, children }) {
+  const storeRef = useRef(service || createMessageService({ bus }))
   const store = storeRef.current
   const message = useSyncExternalStore(
     store.subscribe,

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -14,6 +14,7 @@ import { ThemeProvider } from './ThemeContext.jsx'
 import { AppProvider } from './context/AppContext.jsx'
 import { ApiProvider } from './context/ApiContext.jsx'
 import { MessageProvider } from './context/MessageContext.jsx'
+import { createEventBus } from './services/EventBus.js'
 
 // eslint-disable-next-line react-refresh/only-export-components
 function ViewportHeightUpdater() {
@@ -31,6 +32,7 @@ function ViewportHeightUpdater() {
   return null
 }
 
+const eventBus = createEventBus()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
@@ -39,7 +41,7 @@ createRoot(document.getElementById('root')).render(
         <ApiProvider>
           <LanguageProvider>
             <ThemeProvider>
-              <MessageProvider>
+              <MessageProvider bus={eventBus}>
                 <BrowserRouter>
                 <ErrorBoundary>
                   <Suspense fallback={<Loader />}> 

--- a/glancy-site/src/services/EventBus.js
+++ b/glancy-site/src/services/EventBus.js
@@ -1,0 +1,43 @@
+class EventBus {
+  constructor(listeners = new Map()) {
+    this.listeners = listeners
+  }
+
+  on = (event, callback) => {
+    let handlers = this.listeners.get(event)
+    if (!handlers) {
+      handlers = new Set()
+      this.listeners.set(event, handlers)
+    }
+    handlers.add(callback)
+    return () => handlers.delete(callback)
+  }
+
+  emit = (event, payload) => {
+    const handlers = this.listeners.get(event)
+    if (!handlers) return
+    for (const cb of handlers) cb(payload)
+  }
+}
+
+class CompositeEventBus {
+  constructor(buses = []) {
+    this.buses = buses
+  }
+
+  on = (event, callback) => {
+    const unsubs = this.buses.map((bus) => bus.on(event, callback))
+    return () => unsubs.forEach((unsub) => unsub())
+  }
+
+  emit = (event, payload) => {
+    for (const bus of this.buses) bus.emit(event, payload)
+  }
+}
+
+export function createEventBus({ buses = [] } = {}) {
+  return buses.length ? new CompositeEventBus(buses) : new EventBus()
+}
+
+export { EventBus, CompositeEventBus }
+

--- a/glancy-site/src/services/MessageService.js
+++ b/glancy-site/src/services/MessageService.js
@@ -1,33 +1,26 @@
+import { createEventBus } from './EventBus.js'
+
 class MessageService {
-  constructor() {
+  constructor(bus = createEventBus()) {
     this.current = ''
-    this.listeners = new Set()
+    this.bus = bus
   }
 
   getSnapshot = () => this.current
 
-  subscribe = (callback) => {
-    this.listeners.add(callback)
-    return () => this.listeners.delete(callback)
-  }
+  subscribe = (callback) => this.bus.on('message', () => callback())
 
   show = (msg) => {
     this.current = msg
-    this._emit()
+    this.bus.emit('message', this.current)
   }
 
   clear = () => {
     this.current = ''
-    this._emit()
-  }
-
-  _emit = () => {
-    for (const cb of this.listeners) {
-      cb()
-    }
+    this.bus.emit('message', this.current)
   }
 }
 
-export function createMessageService() {
-  return new MessageService()
+export function createMessageService({ bus } = {}) {
+  return new MessageService(bus)
 }


### PR DESCRIPTION
### Summary
- Introduced a composable event bus to allow multiple buses and decouple messaging.
- Refactored message service and provider to use injected event buses.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6890863b6e508332b08d0c920251c1fd