### PR TITLE
[fix] bind matchMedia to window in theme service

### DIFF
--- a/glancy-site/src/services/ThemeService.js
+++ b/glancy-site/src/services/ThemeService.js
@@ -67,7 +67,7 @@ class ThemeService {
 
 export function createThemeService({
   storage = window.localStorage,
-  matchMedia = window.matchMedia,
+  matchMedia = window.matchMedia.bind(window),
   document = window.document,
   icons,
 } = {}) {


### PR DESCRIPTION
### Summary
- bind `window.matchMedia` to `window` in theme service to avoid illegal invocation errors

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68909ed44e588332a5ae64a66ecf6f94