### PR TITLE
[fix] ensure home page renders

### DIFF
--- a/glancy-site/index.html
+++ b/glancy-site/index.html
@@ -2,30 +2,12 @@
 <html lang="zh" data-theme="system">
   <head>
     <meta charset="UTF-8" />
-    <link id="favicon" rel="icon" type="image/svg+xml" href="/src/assets/glancy-web-light.svg" />
+    <link id="favicon" rel="icon" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>格律词典</title>
   </head>
   <body>
     <div id="root"></div>
-    <script>
-      ;(function () {
-        const storedLang = localStorage.getItem('lang')
-        if (storedLang) {
-          document.documentElement.lang = storedLang
-        }
-        const theme = localStorage.getItem('theme') || 'system'
-        const dark = window.matchMedia('(prefers-color-scheme: dark)').matches
-        const resolved = theme === 'system' ? (dark ? 'dark' : 'light') : theme
-        document.documentElement.dataset.theme = resolved
-        const link = document.getElementById('favicon')
-        if (link) {
-          link.href = resolved === 'dark'
-            ? '/src/assets/glancy-web-dark.svg'
-            : '/src/assets/glancy-web-light.svg'
-        }
-      })()
-    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/glancy-site/src/main.jsx
+++ b/glancy-site/src/main.jsx
@@ -15,6 +15,7 @@ import { AppProvider } from './context/AppContext.jsx'
 import { ApiProvider } from './context/ApiContext.jsx'
 import { MessageProvider } from './context/MessageContext.jsx'
 import { createEventBus } from './services/EventBus.js'
+import { setupTheme } from './theme/initTheme.js'
 
 // eslint-disable-next-line react-refresh/only-export-components
 function ViewportHeightUpdater() {
@@ -32,6 +33,7 @@ function ViewportHeightUpdater() {
   return null
 }
 
+setupTheme()
 const eventBus = createEventBus()
 
 createRoot(document.getElementById('root')).render(

--- a/glancy-site/src/theme/initTheme.js
+++ b/glancy-site/src/theme/initTheme.js
@@ -1,0 +1,17 @@
+import lightIcon from '../assets/glancy-web-light.svg'
+import darkIcon from '../assets/glancy-web-dark.svg'
+
+export function setupTheme() {
+  const storedLang = localStorage.getItem('lang')
+  if (storedLang) {
+    document.documentElement.lang = storedLang
+  }
+  const theme = localStorage.getItem('theme') || 'system'
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const resolved = theme === 'system' ? (prefersDark ? 'dark' : 'light') : theme
+  document.documentElement.dataset.theme = resolved
+  const link = document.getElementById('favicon')
+  if (link) {
+    link.href = resolved === 'dark' ? darkIcon : lightIcon
+  }
+}

--- a/glancy-site/vite.config.js
+++ b/glancy-site/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: './',
+  base: '/',
   plugins: [react()],
   server: {
     proxy: {


### PR DESCRIPTION
### Summary
- initialize theme and favicon before React render to avoid blank home page
- build assets from site root for reliable resource loading

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6890a54ef1b08332945df4168549a8b8