### PR TITLE
[fix] prevent infinite history reload

### DIFF
--- a/glancy-site/src/App.jsx
+++ b/glancy-site/src/App.jsx
@@ -32,6 +32,7 @@ function App() {
     const messageService = useMessageService()
   const { user } = useUser()
   const { loadHistory, addHistory, unfavoriteHistory } = useHistory()
+  const loadHistoryRef = useRef(loadHistory)
   const { theme, resolvedTheme, setTheme } = useTheme()
   const inputRef = useRef(null)
   const SendIcon =
@@ -175,8 +176,12 @@ function App() {
   }, [lang, setLang, theme, setTheme, entry, showFavorites, showHistory, toggleFavorite])
 
   useEffect(() => {
-    loadHistory(user)
-  }, [user, loadHistory])
+    loadHistoryRef.current = loadHistory
+  }, [loadHistory])
+
+  useEffect(() => {
+    loadHistoryRef.current(user)
+  }, [user])
 
   useEffect(() => {
     if (!user) {

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useHistory, useFavorites, useUser } from '../../context/AppContext.jsx'
 import { useLanguage } from '../../LanguageContext.jsx'
 import ListItem from '../ListItem/ListItem.jsx'
@@ -12,6 +12,7 @@ import {
 
 function HistoryList({ onSelect }) {
   const { history, loadHistory, removeHistory, favoriteHistory } = useHistory()
+  const loadHistoryRef = useRef(loadHistory)
   const { toggleFavorite } = useFavorites()
   const { user } = useUser()
   const [openIndex, setOpenIndex] = useState(null)
@@ -25,8 +26,12 @@ function HistoryList({ onSelect }) {
   }, [open])
 
   useEffect(() => {
-    loadHistory(user)
-  }, [user, loadHistory])
+    loadHistoryRef.current = loadHistory
+  }, [loadHistory])
+
+  useEffect(() => {
+    loadHistoryRef.current(user)
+  }, [user])
 
   if (history.length === 0) return null
 


### PR DESCRIPTION
### Summary
- Avoid repeated history loads by caching the loader function to stop blank screen

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6890ad597f6c8332b31cce4d40528fce