### PR TITLE
[fix] handle empty search record response

### DIFF
--- a/glancy-site/src/api/client.js
+++ b/glancy-site/src/api/client.js
@@ -37,9 +37,15 @@ export function createApiClient({ token, headers: defaultHeaders = {} } = {}) {
       throw new Error(extractMessage(text) || 'Request failed')
     }
 
+    if (resp.status === 204 || resp.headers.get('content-length') === '0') {
+      logger.debug('apiRequest success', { url })
+      return null
+    }
+
     const contentType = resp.headers.get('content-type') || ''
     if (contentType.includes('application/json')) {
-      const data = await resp.json()
+      const text = await resp.text()
+      const data = text ? JSON.parse(text) : null
       logger.debug('apiRequest success', { url })
       return data
     }

--- a/glancy-site/src/store/historyStore.ts
+++ b/glancy-site/src/store/historyStore.ts
@@ -32,9 +32,10 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
         userId: user.id,
         token: user.token
       })
-      const terms = records.map((r) => r.term)
+      const normalized = Array.isArray(records) ? records : []
+      const terms = normalized.map((r) => r.term)
       const map: Record<string, string> = {}
-      records.forEach((r) => {
+      normalized.forEach((r) => {
         if (r.id) map[r.term] = r.id
       })
       const existing = get().history
@@ -69,9 +70,11 @@ export const useHistoryStore = create<HistoryState>((set, get) => {
             term,
             language
           })
-          set((state) => ({
-            recordMap: { ...state.recordMap, [term]: record.id }
-          }))
+          if (record && record.id) {
+            set((state) => ({
+              recordMap: { ...state.recordMap, [term]: record.id }
+            }))
+          }
           // refresh history from server to ensure sync
           refreshHistory(user)
         } catch (err) {


### PR DESCRIPTION
### Summary
- handle empty or no-content responses in API client
- guard history store when search record requests return nothing

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6890be2562888332921c828080abec28