### PR TITLE
[fix] ensure history action menu toggles correctly

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useHistory, useFavorites, useUser } from '../../context/AppContext.jsx'
 import { useLanguage } from '../../LanguageContext.jsx'
 import ListItem from '../ListItem/ListItem.jsx'
@@ -22,10 +22,32 @@ function HistoryList({ onSelect }) {
   } = useOutsideToggle(false)
   const { t } = useLanguage()
 
-  const closeMenu = () => {
+  const closeMenu = useCallback(() => {
     setOpen(false)
     setOpenIndex(null)
-  }
+  }, [setOpen, setOpenIndex])
+
+  const toggleMenu = useCallback((e, index) => {
+    e.stopPropagation()
+    setOpenIndex(prev => {
+      const nextIndex = prev === index ? null : index
+      setOpen(nextIndex !== null)
+      return nextIndex
+    })
+  }, [setOpen, setOpenIndex])
+
+  const handleFavorite = useCallback((e, item) => {
+    e.stopPropagation()
+    favoriteHistory(item, user)
+    toggleFavorite(item)
+    closeMenu()
+  }, [favoriteHistory, toggleFavorite, user, closeMenu])
+
+  const handleDelete = useCallback((e, item) => {
+    e.stopPropagation()
+    removeHistory(item, user)
+    closeMenu()
+  }, [removeHistory, user, closeMenu])
 
   useEffect(() => {
     if (!open) {
@@ -52,14 +74,7 @@ function HistoryList({ onSelect }) {
                 <button
                   type="button"
                   className={styles['history-action']}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    setOpenIndex(prev => {
-                      const nextIndex = prev === i ? null : i
-                      setOpen(nextIndex !== null)
-                      return nextIndex
-                    })
-                  }}
+                  onClick={(e) => toggleMenu(e, i)}
                 >
                   <EllipsisVerticalIcon width={16} height={16} />
                 </button>
@@ -68,12 +83,7 @@ function HistoryList({ onSelect }) {
                     <button
                       type="button"
                       title={t.favoriteAction}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        favoriteHistory(h, user)
-                        toggleFavorite(h)
-                        closeMenu()
-                      }}
+                      onClick={(e) => handleFavorite(e, h)}
                     >
                       <StarSolidIcon width={16} height={16} className={styles.icon} />
                     </button>
@@ -81,11 +91,7 @@ function HistoryList({ onSelect }) {
                       type="button"
                       title={t.deleteAction}
                       className={styles['delete-btn']}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        removeHistory(h, user)
-                        closeMenu()
-                      }}
+                      onClick={(e) => handleDelete(e, h)}
                     >
                       <TrashIcon width={16} height={16} className={styles.icon} />
                     </button>


### PR DESCRIPTION
### Summary
- refactor history list action menu to use memoized handlers that open and close reliably

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6890cc85f81c8332ace4b2c52e949a6e