### PR TITLE
[fix] enable history item action menus

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryItemActions.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryItemActions.jsx
@@ -1,0 +1,58 @@
+import { useCallback } from 'react'
+import useOutsideToggle from '../../hooks/useOutsideToggle.js'
+import { EllipsisVerticalIcon, StarSolidIcon, TrashIcon } from '../Icon'
+import styles from './Sidebar.module.css'
+
+function HistoryItemActions({ term, onFavorite, onDelete, t }) {
+  const { open, setOpen, ref } = useOutsideToggle(false)
+
+  const toggleMenu = useCallback((e) => {
+    e.stopPropagation()
+    setOpen(o => !o)
+  }, [setOpen])
+
+  const handleFavorite = useCallback((e) => {
+    e.stopPropagation()
+    onFavorite(term)
+    setOpen(false)
+  }, [onFavorite, term, setOpen])
+
+  const handleDelete = useCallback((e) => {
+    e.stopPropagation()
+    onDelete(term)
+    setOpen(false)
+  }, [onDelete, term, setOpen])
+
+  return (
+    <div className={styles['history-action-wrapper']} ref={ref}>
+      <button
+        type="button"
+        className={styles['history-action']}
+        onClick={toggleMenu}
+      >
+        <EllipsisVerticalIcon width={16} height={16} />
+      </button>
+      {open && (
+        <div className={styles['history-menu']}>
+          <button
+            type="button"
+            title={t.favoriteAction}
+            onClick={handleFavorite}
+          >
+            <StarSolidIcon width={16} height={16} className={styles.icon} />
+          </button>
+          <button
+            type="button"
+            title={t.deleteAction}
+            className={styles['delete-btn']}
+            onClick={handleDelete}
+          >
+            <TrashIcon width={16} height={16} className={styles.icon} />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default HistoryItemActions

--- a/glancy-site/src/components/Sidebar/HistoryList.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryList.jsx
@@ -1,59 +1,24 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useCallback } from 'react'
 import { useHistory, useFavorites, useUser } from '../../context/AppContext.jsx'
 import { useLanguage } from '../../LanguageContext.jsx'
 import ListItem from '../ListItem/ListItem.jsx'
 import styles from './Sidebar.module.css'
-import useOutsideToggle from '../../hooks/useOutsideToggle.js'
-import {
-  EllipsisVerticalIcon,
-  StarSolidIcon,
-  TrashIcon
-} from '../Icon'
+import HistoryItemActions from './HistoryItemActions.jsx'
 
 function HistoryList({ onSelect }) {
   const { history, loadHistory, removeHistory, favoriteHistory } = useHistory()
   const { toggleFavorite } = useFavorites()
   const { user } = useUser()
-  const [openIndex, setOpenIndex] = useState(null)
-  const {
-    ref: listRef,
-    open,
-    setOpen
-  } = useOutsideToggle(false)
   const { t } = useLanguage()
 
-  const closeMenu = useCallback(() => {
-    setOpen(false)
-    setOpenIndex(null)
-  }, [setOpen, setOpenIndex])
-
-  const toggleMenu = useCallback((e, index) => {
-    e.stopPropagation()
-    setOpenIndex(prev => {
-      const nextIndex = prev === index ? null : index
-      setOpen(nextIndex !== null)
-      return nextIndex
-    })
-  }, [setOpen, setOpenIndex])
-
-  const handleFavorite = useCallback((e, item) => {
-    e.stopPropagation()
+  const handleFavorite = useCallback((item) => {
     favoriteHistory(item, user)
     toggleFavorite(item)
-    closeMenu()
-  }, [favoriteHistory, toggleFavorite, user, closeMenu])
+  }, [favoriteHistory, toggleFavorite, user])
 
-  const handleDelete = useCallback((e, item) => {
-    e.stopPropagation()
+  const handleDelete = useCallback((item) => {
     removeHistory(item, user)
-    closeMenu()
-  }, [removeHistory, user, closeMenu])
-
-  useEffect(() => {
-    if (!open) {
-      setOpenIndex(null)
-    }
-  }, [open])
+  }, [removeHistory, user])
 
   useEffect(() => {
     loadHistory(user)
@@ -62,7 +27,7 @@ function HistoryList({ onSelect }) {
   if (history.length === 0) return null
 
   return (
-    <div className={`${styles['sidebar-section']} ${styles['history-list']}`} ref={listRef}>
+    <div className={`${styles['sidebar-section']} ${styles['history-list']}`}>
       <ul>
         {history.map((h, i) => (
           <ListItem
@@ -70,34 +35,12 @@ function HistoryList({ onSelect }) {
             text={h}
             onClick={() => onSelect && onSelect(h)}
             actions={(
-              <div className={styles['history-action-wrapper']}>
-                <button
-                  type="button"
-                  className={styles['history-action']}
-                  onClick={(e) => toggleMenu(e, i)}
-                >
-                  <EllipsisVerticalIcon width={16} height={16} />
-                </button>
-                {openIndex === i && (
-                  <div className={styles['history-menu']}>
-                    <button
-                      type="button"
-                      title={t.favoriteAction}
-                      onClick={(e) => handleFavorite(e, h)}
-                    >
-                      <StarSolidIcon width={16} height={16} className={styles.icon} />
-                    </button>
-                    <button
-                      type="button"
-                      title={t.deleteAction}
-                      className={styles['delete-btn']}
-                      onClick={(e) => handleDelete(e, h)}
-                    >
-                      <TrashIcon width={16} height={16} className={styles.icon} />
-                    </button>
-                  </div>
-                )}
-              </div>
+              <HistoryItemActions
+                term={h}
+                t={t}
+                onFavorite={handleFavorite}
+                onDelete={handleDelete}
+              />
             )}
           />
         ))}


### PR DESCRIPTION
### Summary
- ensure each history item can toggle its action menu via a dedicated component

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6890d07ebbd083328dfddfbfd63e85d3