### PR TITLE
[fix] ensure sidebar history menu toggles

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryItemActions.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryItemActions.jsx
@@ -7,18 +7,27 @@ function HistoryItemActions({ term, onFavorite, onDelete, t }) {
   const { open, setOpen, ref } = useOutsideToggle(false)
 
   const toggleMenu = useCallback((e) => {
+    e.preventDefault()
     e.stopPropagation()
-    setOpen(o => !o)
-  }, [setOpen])
+    setOpen(prev => {
+      const next = !prev
+      console.log('HistoryItemActions: toggle menu', { term, next })
+      return next
+    })
+  }, [setOpen, term])
 
   const handleFavorite = useCallback((e) => {
+    e.preventDefault()
     e.stopPropagation()
+    console.log('HistoryItemActions: favorite', term)
     onFavorite(term)
     setOpen(false)
   }, [onFavorite, term, setOpen])
 
   const handleDelete = useCallback((e) => {
+    e.preventDefault()
     e.stopPropagation()
+    console.log('HistoryItemActions: delete', term)
     onDelete(term)
     setOpen(false)
   }, [onDelete, term, setOpen])

--- a/glancy-site/src/hooks/useOutsideToggle.js
+++ b/glancy-site/src/hooks/useOutsideToggle.js
@@ -1,18 +1,27 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 
 export default function useOutsideToggle(initialOpen = false) {
   const [open, setOpen] = useState(initialOpen)
   const ref = useRef(null)
 
+  const logSetOpen = useCallback((next) => {
+    console.log('useOutsideToggle:setOpen', next)
+    setOpen(next)
+  }, [])
+
   useEffect(() => {
+    console.log('useOutsideToggle: open changed', open)
+
     function handleStart(e) {
       if (ref.current && !ref.current.contains(e.target)) {
+        console.log('useOutsideToggle: outside interaction', e.target)
         setOpen(false)
       }
     }
 
     function handleKeyDown(e) {
       if (e.key === 'Escape') {
+        console.log('useOutsideToggle: escape pressed')
         setOpen(false)
       }
     }
@@ -30,5 +39,5 @@ export default function useOutsideToggle(initialOpen = false) {
     }
   }, [open])
 
-  return { open, setOpen, ref }
+  return { open, setOpen: logSetOpen, ref }
 }


### PR DESCRIPTION
### Summary
- improve outside toggle hook with detailed console logs
- log history menu actions and prevent default behavior to keep menu open

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6890d3afc6b0833294aabbbc1db1484d