### PR TITLE
[fix] history menu toggle

### DIFF
--- a/glancy-site/src/components/Sidebar/HistoryItemActions.jsx
+++ b/glancy-site/src/components/Sidebar/HistoryItemActions.jsx
@@ -4,22 +4,17 @@ import { EllipsisVerticalIcon, StarSolidIcon, TrashIcon } from '../Icon'
 import styles from './Sidebar.module.css'
 
 function HistoryItemActions({ term, onFavorite, onDelete, t }) {
-  const { open, setOpen, ref } = useOutsideToggle(false)
+  const { open, toggle, setOpen, ref } = useOutsideToggle(false)
 
   const toggleMenu = useCallback((e) => {
     e.preventDefault()
     e.stopPropagation()
-    setOpen(prev => {
-      const next = !prev
-      console.log('HistoryItemActions: toggle menu', { term, next })
-      return next
-    })
-  }, [setOpen, term])
+    toggle()
+  }, [toggle])
 
   const handleFavorite = useCallback((e) => {
     e.preventDefault()
     e.stopPropagation()
-    console.log('HistoryItemActions: favorite', term)
     onFavorite(term)
     setOpen(false)
   }, [onFavorite, term, setOpen])
@@ -27,7 +22,6 @@ function HistoryItemActions({ term, onFavorite, onDelete, t }) {
   const handleDelete = useCallback((e) => {
     e.preventDefault()
     e.stopPropagation()
-    console.log('HistoryItemActions: delete', term)
     onDelete(term)
     setOpen(false)
   }, [onDelete, term, setOpen])

--- a/glancy-site/src/hooks/useOutsideToggle.js
+++ b/glancy-site/src/hooks/useOutsideToggle.js
@@ -4,40 +4,37 @@ export default function useOutsideToggle(initialOpen = false) {
   const [open, setOpen] = useState(initialOpen)
   const ref = useRef(null)
 
-  const logSetOpen = useCallback((next) => {
-    console.log('useOutsideToggle:setOpen', next)
-    setOpen(next)
+  const updateOpen = useCallback((next) => {
+    setOpen(prev => (typeof next === 'function' ? next(prev) : next))
   }, [])
 
-  useEffect(() => {
-    console.log('useOutsideToggle: open changed', open)
+  const toggle = useCallback(() => {
+    updateOpen(prev => !prev)
+  }, [updateOpen])
 
-    function handleStart(e) {
+  useEffect(() => {
+    function handlePointerDown(e) {
       if (ref.current && !ref.current.contains(e.target)) {
-        console.log('useOutsideToggle: outside interaction', e.target)
-        setOpen(false)
+        updateOpen(false)
       }
     }
 
     function handleKeyDown(e) {
       if (e.key === 'Escape') {
-        console.log('useOutsideToggle: escape pressed')
-        setOpen(false)
+        updateOpen(false)
       }
     }
 
     if (open) {
-      document.addEventListener('mousedown', handleStart)
-      document.addEventListener('touchstart', handleStart)
+      document.addEventListener('pointerdown', handlePointerDown)
       document.addEventListener('keydown', handleKeyDown)
     }
 
     return () => {
-      document.removeEventListener('mousedown', handleStart)
-      document.removeEventListener('touchstart', handleStart)
+      document.removeEventListener('pointerdown', handlePointerDown)
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [open])
+  }, [open, updateOpen])
 
-  return { open, setOpen: logSetOpen, ref }
+  return { open, setOpen: updateOpen, toggle, ref }
 }


### PR DESCRIPTION
### Summary
- ensure outside toggle hook supports pointer interactions and toggling
- use new toggle hook in history action menu to display correctly

### Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890d7cf474c833284187dbd6701f499