### PR TITLE
[fix] remove redundant CSS shorthand values

### DIFF
--- a/glancy-site/src/components/Layout.module.css
+++ b/glancy-site/src/components/Layout.module.css
@@ -36,7 +36,7 @@
   display: flex;
   align-items: center;
   box-sizing: border-box;
-  padding: 0 20px 0 20px;
+  padding: 0 20px;
 }
 
 @media (width <= 600px) {

--- a/glancy-site/src/components/Sidebar/Sidebar.module.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.module.css
@@ -18,7 +18,7 @@
   align-items: center;
   gap: 0.5rem;
   height: var(--bar-height);
-  padding: 0 20px 0 20px;
+  padding: 0 20px;
   position: sticky;
   bottom: 0;
   background: inherit;


### PR DESCRIPTION
### Summary
- Simplified padding shorthands in layout and sidebar styles to eliminate redundant values.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run lint:css` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6890dc77bc548332a322120e3d37dedb