### PR TITLE
[feature] add unit tests

### DIFF
--- a/glancy-site/eslint.config.js
+++ b/glancy-site/eslint.config.js
@@ -33,7 +33,7 @@ export default defineConfig([
     },
   },
   {
-    files: ['**/__tests__/**/*.js'],
+    files: ['**/__tests__/**/*.{js,jsx,ts,tsx}'],
     languageOptions: {
       globals: {
         ...globals.node,

--- a/glancy-site/jest.config.js
+++ b/glancy-site/jest.config.js
@@ -1,11 +1,22 @@
 export default {
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-    '^.+\\.css$': 'identity-obj-proxy'
+    '^.+\\.css$': 'identity-obj-proxy',
+    '^.+\\.(svg)$': '<rootDir>/test/__mocks__/fileMock.js'
   },
-  extensionsToTreatAsEsm: ['.jsx'],
+  extensionsToTreatAsEsm: ['.jsx', '.ts', '.tsx'],
   transform: {
-    '^.+\\.(jsx?)$': ['babel-jest', { presets: ['@babel/preset-react'] }]
-  }
+    '^.+\\.(t|j)sx?$': [
+      'babel-jest',
+      {
+        presets: [
+          ['@babel/preset-react', { runtime: 'automatic' }],
+          '@babel/preset-typescript'
+        ]
+      }
+    ]
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom'],
+  collectCoverage: false
 }

--- a/glancy-site/package-lock.json
+++ b/glancy-site/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@babel/preset-react": "^7.27.1",
+        "@babel/preset-typescript": "^7.27.1",
         "@eslint/js": "^9.30.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -179,12 +180,48 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
+      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.27.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -221,12 +258,57 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
       "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -530,6 +612,23 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+      "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-react-display-name": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
@@ -631,6 +730,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
+      "integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/preset-react": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.27.1.tgz",
@@ -644,6 +763,26 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "start": "node server.js",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest --runInBand",
     "lint:css": "stylelint \"src/**/*.css\""
   },
   "dependencies": {
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@eslint/js": "^9.30.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/glancy-site/src/__tests__/Login.test.jsx
+++ b/glancy-site/src/__tests__/Login.test.jsx
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import { API_PATHS } from '../config/api.js'
+
+const mockSetUser = jest.fn()
+const mockRequest = jest.fn().mockResolvedValue({ id: '1', token: 't' })
+const mockNavigate = jest.fn()
+
+jest.unstable_mockModule('../context/AppContext.jsx', () => ({
+  useUser: () => ({ setUser: mockSetUser })
+}))
+jest.unstable_mockModule('../hooks/useApi.js', () => ({
+  useApi: () => ({ request: mockRequest })
+}))
+jest.unstable_mockModule('../ThemeContext.jsx', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' })
+}))
+jest.unstable_mockModule('react-router-dom', async () => {
+  const actual = await import('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const router = await import('react-router-dom')
+const { MemoryRouter } = router
+const { default: Login } = await import('../Login.jsx')
+
+test('logs in and navigates home', async () => {
+  render(
+    <MemoryRouter>
+      <Login />
+    </MemoryRouter>
+  )
+  fireEvent.change(screen.getByPlaceholderText('Phone number'), {
+    target: { value: '1234567' }
+  })
+  fireEvent.change(screen.getByPlaceholderText('Password / code'), {
+    target: { value: 'pass' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+  await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+  expect(mockRequest).toHaveBeenCalledWith(API_PATHS.login, expect.any(Object))
+  await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith({ id: '1', token: 't' }))
+  expect(mockNavigate).toHaveBeenCalledWith('/')
+})

--- a/glancy-site/src/__tests__/Preferences.test.jsx
+++ b/glancy-site/src/__tests__/Preferences.test.jsx
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import { API_PATHS } from '../config/api.js'
+
+const mockRequest = jest.fn().mockResolvedValue({})
+const mockFetchModels = jest.fn().mockResolvedValue(['M1'])
+const mockSetTheme = jest.fn()
+const mockSetModel = jest.fn()
+const mockT = {
+  prefTitle: 'Preferences',
+  prefLanguage: 'Language',
+  prefSearchLanguage: 'Search Language',
+  prefDictionaryModel: 'Model',
+  prefTheme: 'Theme',
+  saveButton: 'Save',
+  saveSuccess: 'Saved',
+  fail: 'Fail',
+  autoDetect: 'Auto',
+  CHINESE: 'CHINESE',
+  ENGLISH: 'ENGLISH',
+  M1: 'M1'
+}
+
+jest.unstable_mockModule('../LanguageContext.jsx', () => ({
+  useLanguage: () => ({ t: mockT })
+}))
+jest.unstable_mockModule('../ThemeContext.jsx', () => ({
+  useTheme: () => ({ theme: 'light', setTheme: mockSetTheme })
+}))
+jest.unstable_mockModule('../context/AppContext.jsx', () => ({
+  useUser: () => ({ user: { id: '1', token: 't' } })
+}))
+jest.unstable_mockModule('../hooks/useApi.js', () => ({
+  useApi: () => ({ request: mockRequest, llm: { fetchModels: mockFetchModels } })
+}))
+jest.unstable_mockModule('../store/modelStore.ts', () => ({
+  useModelStore: () => ({ model: 'M1', setModel: mockSetModel })
+}))
+
+const { default: Preferences } = await import('../Preferences.jsx')
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+test('saves preferences via api', async () => {
+  render(<Preferences />)
+  await waitFor(() => expect(mockFetchModels).toHaveBeenCalled())
+  fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'CHINESE' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+  await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+  expect(mockRequest.mock.calls[0][0]).toBe(`${API_PATHS.preferences}/user/1`)
+})

--- a/glancy-site/src/__tests__/Register.test.jsx
+++ b/glancy-site/src/__tests__/Register.test.jsx
@@ -1,0 +1,50 @@
+/* eslint-env jest */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import { API_PATHS } from '../config/api.js'
+
+const mockSetUser = jest.fn()
+const mockRequest = jest
+  .fn()
+  .mockResolvedValueOnce(undefined)
+  .mockResolvedValueOnce({ id: '1', token: 't' })
+const mockNavigate = jest.fn()
+
+jest.unstable_mockModule('../context/AppContext.jsx', () => ({
+  useUser: () => ({ setUser: mockSetUser })
+}))
+jest.unstable_mockModule('../hooks/useApi.js', () => ({
+  useApi: () => ({ request: mockRequest })
+}))
+jest.unstable_mockModule('../ThemeContext.jsx', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' })
+}))
+jest.unstable_mockModule('react-router-dom', async () => {
+  const actual = await import('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const router = await import('react-router-dom')
+const { MemoryRouter } = router
+const { default: Register } = await import('../Register.jsx')
+
+test('registers and logs in user', async () => {
+  render(
+    <MemoryRouter>
+      <Register />
+    </MemoryRouter>
+  )
+  fireEvent.change(screen.getByPlaceholderText('Phone number'), {
+    target: { value: '1234567' }
+  })
+  fireEvent.change(screen.getByPlaceholderText('Code'), {
+    target: { value: '0000' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
+  expect(mockRequest.mock.calls[0][0]).toBe(API_PATHS.register)
+  expect(mockRequest.mock.calls[1][0]).toBe(API_PATHS.login)
+  await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith({ id: '1', token: 't' }))
+  expect(mockNavigate).toHaveBeenCalledWith('/')
+})

--- a/glancy-site/src/api/__tests__/chat.test.js
+++ b/glancy-site/src/api/__tests__/chat.test.js
@@ -1,0 +1,12 @@
+import { createChatApi } from '../chat.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('sendChatMessage posts to chat endpoint', async () => {
+  const request = jest.fn().mockResolvedValue('ok')
+  const api = createChatApi(request)
+  await api.sendChatMessage('hi')
+  expect(request).toHaveBeenCalledWith(API_PATHS.chat, expect.objectContaining({
+    method: 'POST'
+  }))
+})

--- a/glancy-site/src/api/__tests__/client.test.js
+++ b/glancy-site/src/api/__tests__/client.test.js
@@ -5,6 +5,7 @@ import { createApiClient } from '../client.js'
 describe('apiRequest error handling', () => {
   afterEach(() => {
     jest.restoreAllMocks()
+    delete global.fetch
   })
 
   test('throws message from JSON body on non-ok response', async () => {
@@ -13,7 +14,7 @@ describe('apiRequest error handling', () => {
       text: jest.fn().mockResolvedValue(JSON.stringify({ message: 'Bad request' })),
       headers: { get: () => 'application/json' },
     }
-    jest.spyOn(global, 'fetch').mockResolvedValue(resp)
+    global.fetch = jest.fn().mockResolvedValue(resp)
     const apiRequest = createApiClient()
     await expect(apiRequest('/api')).rejects.toThrow('Bad request')
   })
@@ -24,7 +25,7 @@ describe('apiRequest error handling', () => {
       text: jest.fn().mockResolvedValue('Server error'),
       headers: { get: () => 'text/plain' },
     }
-    jest.spyOn(global, 'fetch').mockResolvedValue(resp)
+    global.fetch = jest.fn().mockResolvedValue(resp)
     const apiRequest = createApiClient()
     await expect(apiRequest('/api')).rejects.toThrow('Server error')
   })

--- a/glancy-site/src/api/__tests__/llm.test.js
+++ b/glancy-site/src/api/__tests__/llm.test.js
@@ -1,0 +1,11 @@
+import { createLlmApi } from '../llm.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('fetchModels hits llm models endpoint', async () => {
+  const request = jest.fn().mockResolvedValue(['a'])
+  const api = createLlmApi(request)
+  const result = await api.fetchModels()
+  expect(request).toHaveBeenCalledWith(API_PATHS.llmModels)
+  expect(result).toEqual(['a'])
+})

--- a/glancy-site/src/api/__tests__/locale.test.js
+++ b/glancy-site/src/api/__tests__/locale.test.js
@@ -1,0 +1,10 @@
+import { createLocaleApi } from '../locale.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('getLocale fetches locale endpoint', async () => {
+  const request = jest.fn().mockResolvedValue({})
+  const api = createLocaleApi(request)
+  await api.getLocale()
+  expect(request).toHaveBeenCalledWith(API_PATHS.locale)
+})

--- a/glancy-site/src/api/__tests__/profiles.test.js
+++ b/glancy-site/src/api/__tests__/profiles.test.js
@@ -1,0 +1,18 @@
+import { createProfilesApi } from '../profiles.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('fetchProfile calls correct path', async () => {
+  const request = jest.fn().mockResolvedValue({})
+  const api = createProfilesApi(request)
+  await api.fetchProfile({ userId: '1', token: 't' })
+  expect(request).toHaveBeenCalledWith(`${API_PATHS.profiles}/user/1`, { token: 't' })
+})
+
+test('saveProfile posts profile data', async () => {
+  const request = jest.fn().mockResolvedValue({})
+  const api = createProfilesApi(request)
+  await api.saveProfile({ userId: '1', token: 't', profile: { a: 1 } })
+  expect(request.mock.calls[0][0]).toBe(`${API_PATHS.profiles}/user/1`)
+  expect(request.mock.calls[0][1]).toMatchObject({ method: 'POST', token: 't' })
+})

--- a/glancy-site/src/api/__tests__/searchRecords.test.js
+++ b/glancy-site/src/api/__tests__/searchRecords.test.js
@@ -1,0 +1,17 @@
+import { createSearchRecordsApi } from '../searchRecords.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('fetchSearchRecords calls with token', async () => {
+  const request = jest.fn().mockResolvedValue([])
+  const api = createSearchRecordsApi(request)
+  await api.fetchSearchRecords({ userId: 'u', token: 't' })
+  expect(request).toHaveBeenCalledWith(`${API_PATHS.searchRecords}/user/u`, { token: 't' })
+})
+
+test('deleteSearchRecord uses record id', async () => {
+  const request = jest.fn().mockResolvedValue()
+  const api = createSearchRecordsApi(request)
+  await api.deleteSearchRecord({ userId: 'u', recordId: 'r1', token: 't' })
+  expect(request.mock.calls[0][0]).toBe(`${API_PATHS.searchRecords}/user/u/r1`)
+})

--- a/glancy-site/src/api/__tests__/users.test.js
+++ b/glancy-site/src/api/__tests__/users.test.js
@@ -1,0 +1,14 @@
+import { createUsersApi } from '../users.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('uploadAvatar posts FormData', async () => {
+  const request = jest.fn().mockResolvedValue({})
+  const api = createUsersApi(request)
+  const file = new Blob(['x'], { type: 'text/plain' })
+  await api.uploadAvatar({ userId: '1', token: 't', file })
+  const [url, options] = request.mock.calls[0]
+  expect(url).toBe(`${API_PATHS.users}/1/avatar-file`)
+  expect(options.method).toBe('POST')
+  expect(options.body).toBeInstanceOf(FormData)
+})

--- a/glancy-site/src/api/__tests__/words.test.js
+++ b/glancy-site/src/api/__tests__/words.test.js
@@ -1,0 +1,12 @@
+import { createWordsApi } from '../words.js'
+import { API_PATHS } from '../../config/api.js'
+import { jest } from '@jest/globals'
+
+test('fetchWord builds query string', async () => {
+  const request = jest.fn().mockResolvedValue({})
+  const api = createWordsApi(request)
+  await api.fetchWord({ userId: 'u', term: 'hello', language: 'ENGLISH', model: 'M1', token: 't' })
+  const [url, opts] = request.mock.calls[0]
+  expect(url).toBe(`${API_PATHS.words}?userId=u&term=hello&language=ENGLISH&model=M1`)
+  expect(opts.token).toBe('t')
+})

--- a/glancy-site/src/components/__tests__/AuthForm.test.jsx
+++ b/glancy-site/src/components/__tests__/AuthForm.test.jsx
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('../../ThemeContext.jsx', () => ({
+  useTheme: () => ({ resolvedTheme: 'light' })
+}))
+
+const { default: AuthForm } = await import('../AuthForm.jsx')
+
+describe('AuthForm', () => {
+  test('submits valid credentials', async () => {
+    const handleSubmit = jest.fn().mockResolvedValue(undefined)
+    const { asFragment } = render(
+      <MemoryRouter>
+        <AuthForm
+          title="Login"
+          switchText="Have account?"
+          switchLink="/register"
+          onSubmit={handleSubmit}
+          placeholders={{ username: 'Username' }}
+          formMethods={['username']}
+          methodOrder={['username']}
+        />
+      </MemoryRouter>
+    )
+    fireEvent.change(screen.getByPlaceholderText('Username'), {
+      target: { value: 'alice' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'secret' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    await waitFor(() =>
+      expect(handleSubmit).toHaveBeenCalledWith({
+        account: 'alice',
+        password: 'secret',
+        method: 'username'
+      })
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+
+  test('shows error when validation fails', async () => {
+    const handleSubmit = jest.fn()
+    const validateAccount = () => false
+    render(
+      <MemoryRouter>
+        <AuthForm
+          title="Login"
+          switchText="Have account?"
+          switchLink="/register"
+          onSubmit={handleSubmit}
+          placeholders={{ username: 'Username' }}
+          formMethods={['username']}
+          methodOrder={['username']}
+          validateAccount={validateAccount}
+        />
+      </MemoryRouter>
+    )
+    fireEvent.change(screen.getByPlaceholderText('Username'), {
+      target: { value: '' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(await screen.findByText('Invalid account')).toBeInTheDocument()
+  })
+})

--- a/glancy-site/src/components/__tests__/ErrorBoundary.test.js
+++ b/glancy-site/src/components/__tests__/ErrorBoundary.test.js
@@ -1,6 +1,4 @@
-/** @jest-environment jsdom */
 import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 import ErrorBoundary from '../ErrorBoundary.jsx'
 import React from 'react'
@@ -18,12 +16,11 @@ afterEach(() => {
 })
 
 test('displays fallback UI on error', () => {
-  render(
-    React.createElement(
-      ErrorBoundary,
-      { fallback: React.createElement('div', null, 'Fallback') },
-      React.createElement(ProblemChild)
-    )
+  const { asFragment } = render(
+    <ErrorBoundary fallback={<div>Fallback</div>}>
+      <ProblemChild />
+    </ErrorBoundary>
   )
   expect(screen.getByText('Fallback')).toBeInTheDocument()
+  expect(asFragment()).toMatchSnapshot()
 })

--- a/glancy-site/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
+++ b/glancy-site/src/components/__tests__/__snapshots__/AuthForm.test.jsx.snap
@@ -1,0 +1,106 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`AuthForm submits valid credentials 1`] = `
+<DocumentFragment>
+  <div
+    class="auth-page"
+  >
+    <a
+      class="auth-close"
+      href="/"
+    >
+      ×
+    </a>
+    <img
+      alt="glancy-web-light"
+      class="auth-logo"
+      src="file-mock"
+    />
+    <div
+      class="auth-brand"
+    >
+      Glancy
+    </div>
+    <h1
+      class="auth-title"
+    >
+      Login
+    </h1>
+    <form
+      class="auth-form"
+    >
+      <input
+        class="auth-input"
+        placeholder="Username"
+        value="alice"
+      />
+      <div
+        class="password-row"
+      >
+        <input
+          class="auth-input"
+          placeholder="Password"
+          type="password"
+          value="secret"
+        />
+      </div>
+      <button
+        class="button auth-primary-btn"
+        type="submit"
+      >
+        Continue
+      </button>
+    </form>
+    <div
+      class="auth-switch"
+    >
+      Have account? 
+      <a
+        href="/register"
+      >
+        Sign up
+      </a>
+    </div>
+    <div
+      class="divider"
+    >
+      <span>
+        OR
+      </span>
+    </div>
+    <div
+      class="login-options"
+    />
+    <div
+      class="auth-footer"
+    >
+      <div
+        class="footer-links"
+      >
+        <a
+          href="#"
+        >
+          Terms of Use
+        </a>
+         | 
+        <a
+          href="#"
+        >
+          Privacy Policy
+        </a>
+      </div>
+      <div
+        class="icp"
+      >
+        <a
+          href="https://beian.miit.gov.cn/"
+          rel="noopener"
+          target="_blank"
+        >
+          京ICP备2025135702号-1
+        </a>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/glancy-site/src/components/__tests__/__snapshots__/ErrorBoundary.test.js.snap
+++ b/glancy-site/src/components/__tests__/__snapshots__/ErrorBoundary.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`displays fallback UI on error 1`] = `
+<DocumentFragment>
+  <div
+    class="error-boundary"
+  >
+    <div>
+      Fallback
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/glancy-site/src/store/__tests__/favoritesStore.test.js
+++ b/glancy-site/src/store/__tests__/favoritesStore.test.js
@@ -1,0 +1,13 @@
+import { act } from '@testing-library/react'
+import { useFavoritesStore } from '../favoritesStore.ts'
+
+describe('favoritesStore', () => {
+  beforeEach(() => localStorage.clear())
+
+  test('toggleFavorite adds and removes terms', () => {
+    act(() => useFavoritesStore.getState().toggleFavorite('hello'))
+    expect(useFavoritesStore.getState().favorites).toContain('hello')
+    act(() => useFavoritesStore.getState().toggleFavorite('hello'))
+    expect(useFavoritesStore.getState().favorites).not.toContain('hello')
+  })
+})

--- a/glancy-site/src/store/__tests__/historyStore.test.js
+++ b/glancy-site/src/store/__tests__/historyStore.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals'
+import { act } from '@testing-library/react'
+import api from '../../api/index.js'
+import { useHistoryStore } from '../historyStore.ts'
+
+const mockApi = api
+mockApi.searchRecords = {
+  fetchSearchRecords: jest.fn().mockResolvedValue([]),
+  saveSearchRecord: jest.fn().mockResolvedValue({ id: 'r1' }),
+  clearSearchRecords: jest.fn().mockResolvedValue(undefined),
+  deleteSearchRecord: jest.fn().mockResolvedValue(undefined),
+  favoriteSearchRecord: jest.fn().mockResolvedValue(undefined),
+  unfavoriteSearchRecord: jest.fn().mockResolvedValue(undefined)
+}
+
+const user = { id: 'u1', token: 't' }
+
+describe('historyStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    jest.clearAllMocks()
+  })
+
+  test('addHistory stores term and calls api', async () => {
+    await act(async () => {
+      await useHistoryStore.getState().addHistory('test', user, 'ENGLISH')
+    })
+    expect(mockApi.searchRecords.saveSearchRecord).toHaveBeenCalled()
+    expect(useHistoryStore.getState().history[0]).toBe('test')
+  })
+
+  test('clearHistory empties store', async () => {
+    await act(async () => {
+      await useHistoryStore.getState().addHistory('a', user)
+    })
+    await act(async () => {
+      await useHistoryStore.getState().clearHistory(user)
+    })
+    expect(useHistoryStore.getState().history).toHaveLength(0)
+  })
+})

--- a/glancy-site/src/store/__tests__/modelStore.test.js
+++ b/glancy-site/src/store/__tests__/modelStore.test.js
@@ -1,0 +1,12 @@
+import { act } from '@testing-library/react'
+import { useModelStore } from '../modelStore.ts'
+
+describe('modelStore', () => {
+  beforeEach(() => localStorage.clear())
+
+  test('setModel updates state and storage', () => {
+    act(() => useModelStore.getState().setModel('GPT'))
+    expect(useModelStore.getState().model).toBe('GPT')
+    expect(localStorage.getItem('dictionaryModel')).toBe('GPT')
+  })
+})

--- a/glancy-site/src/store/__tests__/userStore.test.js
+++ b/glancy-site/src/store/__tests__/userStore.test.js
@@ -1,0 +1,18 @@
+import { act } from '@testing-library/react'
+import { useUserStore } from '../userStore.ts'
+
+describe('userStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  test('setUser and clearUser persist to storage', () => {
+    const user = { id: '1', token: 't' }
+    act(() => useUserStore.getState().setUser(user))
+    expect(useUserStore.getState().user).toEqual(user)
+    expect(localStorage.getItem('user')).toBe(JSON.stringify(user))
+    act(() => useUserStore.getState().clearUser())
+    expect(useUserStore.getState().user).toBeNull()
+    expect(localStorage.getItem('user')).toBeNull()
+  })
+})

--- a/glancy-site/test/__mocks__/fileMock.js
+++ b/glancy-site/test/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+export default 'file-mock'


### PR DESCRIPTION
### Summary
- set up Jest with jsdom and TypeScript support
- add unit and snapshot tests for stores, API utilities, and AuthForm component

### Testing
- `npm test` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6890e796b9f083328d3d3fb2d482a62f