### PR TITLE
[fix] correct ThemeIcon asset path

### DIFF
--- a/glancy-site/src/components/ui/Icon/index.jsx
+++ b/glancy-site/src/components/ui/Icon/index.jsx
@@ -8,7 +8,10 @@ const glob =
     : () => ({})
 
 // use relative paths instead of alias to ensure compatibility across build tools
-const modules = glob('../../assets/**/*.svg', {
+// NOTE: this file lives in `src/components/ui/Icon`, so we need to go up three levels
+// to reach `src/assets`. Keeping this explicit helps future refactors remain aware
+// of the relationship between components and shared assets.
+const modules = glob('../../../assets/**/*.svg', {
   eager: true,
   import: 'default'
 })


### PR DESCRIPTION
### Summary
- ensure ThemeIcon loads icons from src/assets by fixing glob path

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_689226ffcaa88332ac88a04bc4ab370c