### PR TITLE
[fix] handle network errors in API client

### DIFF
--- a/glancy-site/src/api/__tests__/client.test.js
+++ b/glancy-site/src/api/__tests__/client.test.js
@@ -29,4 +29,13 @@ describe('apiRequest error handling', () => {
     const apiRequest = createApiClient()
     await expect(apiRequest('/api')).rejects.toThrow('Server error')
   })
+
+  test('throws unified message on network failure', async () => {
+    const error = new Error('network down')
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    global.fetch = jest.fn().mockRejectedValue(error)
+    const apiRequest = createApiClient()
+    await expect(apiRequest('/api')).rejects.toThrow('Network error')
+    expect(spy).toHaveBeenCalledWith(error)
+  })
 })

--- a/glancy-site/src/api/client.js
+++ b/glancy-site/src/api/client.js
@@ -18,7 +18,13 @@ export function createApiClient({ token, headers: defaultHeaders = {}, onUnautho
     const authToken = reqToken ?? token
     if (authToken) mergedHeaders['X-USER-TOKEN'] = authToken
 
-    const resp = await fetch(url, { ...options, headers: mergedHeaders })
+    let resp
+    try {
+      resp = await fetch(url, { ...options, headers: mergedHeaders })
+    } catch (err) {
+      console.error(err)
+      throw new Error('Network error')
+    }
     if (!resp.ok) {
       if (resp.status === 401) onUnauthorized?.()
       const text = await resp.text().catch((err) => {


### PR DESCRIPTION
### Summary
- wrap fetch in API client with try/catch and surface unified network error
- cover network error scenario in API client tests

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm test` ❌ (heap out of memory)
- `NODE_OPTIONS='--experimental-vm-modules --max-old-space-size=4096' npx jest src/api/__tests__/client.test.js --runInBand` ✅
- `npm run build` ✅

### Notes
- full test suite fails to run due to memory limits; individual test file run succeeds

------
https://chatgpt.com/codex/tasks/task_e_689230228e2483328c0aa08860e66cb3