### PR TITLE
[refactor] extract fetchWord to custom hook

### DIFF
--- a/glancy-site/src/hooks/useFetchWord.js
+++ b/glancy-site/src/hooks/useFetchWord.js
@@ -1,0 +1,25 @@
+import { useApi } from '@/hooks/useApi.js'
+import { detectWordLanguage, clientNameFromModel } from '@/utils/index.js'
+
+export function useFetchWord() {
+  const api = useApi()
+  const { fetchWord } = api.words
+
+  const fetchWordWithHandling = async ({ user, term, model }) => {
+    const language = detectWordLanguage(term)
+    try {
+      const data = await fetchWord({
+        userId: user.id,
+        term,
+        language,
+        model: clientNameFromModel(model),
+        token: user.token
+      })
+      return { data, error: null, language }
+    } catch (error) {
+      return { data: null, error, language }
+    }
+  }
+
+  return { fetchWordWithHandling }
+}


### PR DESCRIPTION
### Summary
- Extract fetchWord fetching and error logic into shared `useFetchWord` hook.
- Simplify App page handlers to consume the hook and manage errors consistently.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ❌ (out-of-memory error)


------
https://chatgpt.com/codex/tasks/task_e_689230485f2483329318cba31d3aa9a1