### PR TITLE
[feature] add media query hook for responsive layout

### DIFF
--- a/glancy-site/src/components/Layout/index.jsx
+++ b/glancy-site/src/components/Layout/index.jsx
@@ -2,11 +2,13 @@ import { useState } from 'react'
 import Sidebar from '@/components/Sidebar'
 import DesktopTopBar from '@/components/TopBar/DesktopTopBar.jsx'
 import MobileTopBar from '@/components/TopBar/MobileTopBar.jsx'
-import { useIsMobile } from '@/utils/index.js'
+import useMediaQuery from '@/hooks/useMediaQuery.js'
 import styles from './Layout.module.css'
 
+const MOBILE_QUERY = '(max-width: 600px)'
+
 function Layout({ children, sidebarProps = {}, topBarProps = {}, bottomContent = null }) {
-  const isMobile = useIsMobile()
+  const isMobile = useMediaQuery(MOBILE_QUERY)
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (

--- a/glancy-site/src/components/Sidebar/Sidebar.jsx
+++ b/glancy-site/src/components/Sidebar/Sidebar.jsx
@@ -1,7 +1,9 @@
 import Brand from '@/components/Brand'
 import SidebarFunctions from './SidebarFunctions.jsx'
 import SidebarUser from './SidebarUser.jsx'
-import { useIsMobile } from '@/utils/index.js'
+import useMediaQuery from '@/hooks/useMediaQuery.js'
+
+const MOBILE_QUERY = '(max-width: 600px)'
 
 function Sidebar({
   isMobile: mobileProp,
@@ -10,7 +12,7 @@ function Sidebar({
   onToggleFavorites,
   onSelectHistory
 }) {
-  const defaultMobile = useIsMobile()
+  const defaultMobile = useMediaQuery(MOBILE_QUERY)
   const isMobile = mobileProp ?? defaultMobile
   return (
     <>

--- a/glancy-site/src/hooks/useMediaQuery.js
+++ b/glancy-site/src/hooks/useMediaQuery.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react'
+
+export default function useMediaQuery(query) {
+  const getMatches = () =>
+    typeof window !== 'undefined' ? window.matchMedia(query).matches : false
+
+  const [matches, setMatches] = useState(getMatches)
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(query)
+    const handleChange = (e) => setMatches(e.matches)
+
+    mediaQueryList.addEventListener
+      ? mediaQueryList.addEventListener('change', handleChange)
+      : mediaQueryList.addListener(handleChange)
+
+    setMatches(mediaQueryList.matches)
+
+    return () => {
+      mediaQueryList.removeEventListener
+        ? mediaQueryList.removeEventListener('change', handleChange)
+        : mediaQueryList.removeListener(handleChange)
+    }
+  }, [query])
+
+  return matches
+}

--- a/glancy-site/src/utils/index.js
+++ b/glancy-site/src/utils/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import useMediaQuery from '@/hooks/useMediaQuery.js'
 
 export function extractMessage(text) {
   if (!text) return ''
@@ -28,19 +28,7 @@ export function getModifierKey() {
 }
 
 export function useIsMobile(maxWidth = 600) {
-  const [isMobile, setIsMobile] = useState(
-    typeof window !== 'undefined' ? window.innerWidth <= maxWidth : false
-  )
-
-  useEffect(() => {
-    function handleResize() {
-      setIsMobile(window.innerWidth <= maxWidth)
-    }
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [maxWidth])
-
-  return isMobile
+  return useMediaQuery(`(max-width: ${maxWidth}px)`)
 }
 
 export function detectWordLanguage(text) {


### PR DESCRIPTION
### Summary
- replace window resize polling with matchMedia-powered useIsMobile hook
- introduce reusable useMediaQuery for responsive components

### Testing
- `npm run lint` ✅
- `npm run build` ✅
- `NODE_OPTIONS=--max-old-space-size=4096 npm test` ❌ (JavaScript heap out of memory)

### Notes
- Tests fail due to memory exhaustion despite increased heap limit.


------
https://chatgpt.com/codex/tasks/task_e_6892306ade508332b2d848bfd3e0312e