### PR TITLE
[refactor] modularize utils helpers

### DIFF
--- a/glancy-site/src/api/client.js
+++ b/glancy-site/src/api/client.js
@@ -1,4 +1,4 @@
-import { extractMessage } from '@/utils/index.js'
+import { extractMessage } from '@/utils/json.js'
 
 /**
  * Create a new API client instance with optional default headers and token.

--- a/glancy-site/src/components/form/EditableField/EditableField.jsx
+++ b/glancy-site/src/components/form/EditableField/EditableField.jsx
@@ -19,7 +19,7 @@ function EditableField({
 
   const containerCls = [styles.field, className].filter(Boolean).join(' ')
   const inputCls = [styles.input, inputClassName].filter(Boolean).join(' ')
-  const btnCls = [styles.edit-btn, buttonClassName].filter(Boolean).join(' ')
+  const btnCls = [styles['edit-btn'], buttonClassName].filter(Boolean).join(' ')
 
   const enableEdit = () => setEditing(true)
 

--- a/glancy-site/src/components/modals/ShortcutsModal.jsx
+++ b/glancy-site/src/components/modals/ShortcutsModal.jsx
@@ -1,6 +1,6 @@
 import BaseModal from './BaseModal.jsx'
 import styles from './ShortcutsModal.module.css'
-import { getModifierKey } from '@/utils/index.js'
+import { getModifierKey } from '@/utils/device.js'
 import { useLanguage } from '@/context/LanguageContext.jsx'
 
 function ShortcutsModal({ open, onClose }) {

--- a/glancy-site/src/components/ui/Avatar.jsx
+++ b/glancy-site/src/components/ui/Avatar.jsx
@@ -1,6 +1,6 @@
 import { useUser } from '@/context/AppContext.jsx'
 import { useMemo } from 'react'
-import { cacheBust } from '@/utils/index.js'
+import { cacheBust } from '@/utils/url.js'
 import ThemeIcon from '@/components/ui/Icon'
 import styles from './Avatar.module.css'
 

--- a/glancy-site/src/pages/profile/index.jsx
+++ b/glancy-site/src/pages/profile/index.jsx
@@ -9,7 +9,7 @@ import GenderSelect from '@/components/form/GenderSelect/GenderSelect.jsx'
 import EditableField from '@/components/form/EditableField/EditableField.jsx'
 import { useApi } from '@/hooks/useApi.js'
 import { useUser } from '@/context/AppContext.jsx'
-import { cacheBust } from '@/utils/index.js'
+import { cacheBust } from '@/utils/url.js'
 import ThemeIcon from '@/components/ui/Icon'
 
 function Profile({ onCancel }) {

--- a/glancy-site/src/store/favoritesStore.ts
+++ b/glancy-site/src/store/favoritesStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { safeJSONParse } from '@/utils/index.js'
+import { safeJSONParse } from '@/utils/json.js'
 
 interface FavoritesState {
   favorites: string[]

--- a/glancy-site/src/store/historyStore.ts
+++ b/glancy-site/src/store/historyStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import api from '@/api/index.js'
-import { safeJSONParse } from '@/utils/index.js'
+import { safeJSONParse } from '@/utils/json.js'
 
 import type { User } from './userStore.ts'
 

--- a/glancy-site/src/store/userStore.ts
+++ b/glancy-site/src/store/userStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { safeJSONParse } from '@/utils/index.js'
+import { safeJSONParse } from '@/utils/json.js'
 
 export interface User {
   id: string

--- a/glancy-site/src/utils/device.js
+++ b/glancy-site/src/utils/device.js
@@ -1,0 +1,11 @@
+import useMediaQuery from '@/hooks/useMediaQuery.js'
+
+export function getModifierKey() {
+  const platform =
+    navigator.userAgentData?.platform || navigator.platform || ''
+  return /Mac|iPhone|iPod|iPad/i.test(platform) ? 'Command \u2318' : 'Ctrl \u2303'
+}
+
+export function useIsMobile(maxWidth = 600) {
+  return useMediaQuery(`(max-width: ${maxWidth}px)`)
+}

--- a/glancy-site/src/utils/index.js
+++ b/glancy-site/src/utils/index.js
@@ -1,35 +1,6 @@
-import useMediaQuery from '@/hooks/useMediaQuery.js'
-
-export function extractMessage(text) {
-  if (!text) return ''
-  try {
-    const data = JSON.parse(text)
-    if (data && typeof data === 'object') {
-      return data.message || text
-    }
-  } catch {
-    // not JSON, ignore
-  }
-  return text
-}
-
-export function safeJSONParse(str, defaultValue = null) {
-  try {
-    return JSON.parse(str)
-  } catch {
-    return defaultValue
-  }
-}
-
-export function getModifierKey() {
-  const platform =
-    navigator.userAgentData?.platform || navigator.platform || ''
-  return /Mac|iPhone|iPod|iPad/i.test(platform) ? 'Command \u2318' : 'Ctrl \u2303'
-}
-
-export function useIsMobile(maxWidth = 600) {
-  return useMediaQuery(`(max-width: ${maxWidth}px)`)
-}
+export { extractMessage, safeJSONParse } from './json.js'
+export { getModifierKey, useIsMobile } from './device.js'
+export { isPresignedUrl, cacheBust } from './url.js'
 
 export function detectWordLanguage(text) {
   return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'
@@ -37,28 +8,4 @@ export function detectWordLanguage(text) {
 
 export function clientNameFromModel(model) {
   return model ? model.toLowerCase().replace(/_.*/, '') : ''
-}
-
-const PRESIGNED_QUERY_KEYS = ['Signature', 'OSSAccessKeyId']
-
-export function isPresignedUrl(url) {
-  if (!url) return false
-  try {
-    const base =
-      typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
-    const params = new URL(url, base).searchParams
-    return PRESIGNED_QUERY_KEYS.some((key) => params.has(key))
-  } catch {
-    return PRESIGNED_QUERY_KEYS.some((key) =>
-      new RegExp(`[?&]${key}=`).test(url)
-    )
-  }
-}
-
-export function cacheBust(url) {
-  if (!url) return url
-  if (url.includes('_v=')) return url
-  if (isPresignedUrl(url)) return url
-  const sep = url.includes('?') ? '&' : '?'
-  return `${url}${sep}_v=${Date.now()}`
 }

--- a/glancy-site/src/utils/json.js
+++ b/glancy-site/src/utils/json.js
@@ -1,0 +1,20 @@
+export function extractMessage(text) {
+  if (!text) return ''
+  try {
+    const data = JSON.parse(text)
+    if (data && typeof data === 'object') {
+      return data.message || text
+    }
+  } catch {
+    // not JSON, ignore
+  }
+  return text
+}
+
+export function safeJSONParse(str, defaultValue = null) {
+  try {
+    return JSON.parse(str)
+  } catch {
+    return defaultValue
+  }
+}

--- a/glancy-site/src/utils/url.js
+++ b/glancy-site/src/utils/url.js
@@ -1,0 +1,23 @@
+const PRESIGNED_QUERY_KEYS = ['Signature', 'OSSAccessKeyId']
+
+export function isPresignedUrl(url) {
+  if (!url) return false
+  try {
+    const base =
+      typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+    const params = new URL(url, base).searchParams
+    return PRESIGNED_QUERY_KEYS.some((key) => params.has(key))
+  } catch {
+    return PRESIGNED_QUERY_KEYS.some((key) =>
+      new RegExp(`[?&]${key}=`).test(url)
+    )
+  }
+}
+
+export function cacheBust(url) {
+  if (!url) return url
+  if (url.includes('_v=')) return url
+  if (isPresignedUrl(url)) return url
+  const sep = url.includes('?') ? '&' : '?'
+  return `${url}${sep}_v=${Date.now()}`
+}


### PR DESCRIPTION
### Summary
- Extracted JSON, device, and URL helpers into dedicated modules and re-exported them via the utils index.
- Updated imports across the app to use the new helper modules and cleaned up a stray CSS reference.

### Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923378dcec8332bedef389c8bf794b