### PR TITLE
[refactor] unify mobile detection via useIsMobile

### DIFF
--- a/glancy-site/src/components/Layout/index.jsx
+++ b/glancy-site/src/components/Layout/index.jsx
@@ -2,13 +2,11 @@ import { useState } from 'react'
 import Sidebar from '@/components/Sidebar'
 import DesktopTopBar from '@/components/TopBar/DesktopTopBar.jsx'
 import MobileTopBar from '@/components/TopBar/MobileTopBar.jsx'
-import useMediaQuery from '@/hooks/useMediaQuery.js'
+import { useIsMobile } from '@/utils/index.js'
 import styles from './Layout.module.css'
 
-const MOBILE_QUERY = '(max-width: 600px)'
-
 function Layout({ children, sidebarProps = {}, topBarProps = {}, bottomContent = null }) {
-  const isMobile = useMediaQuery(MOBILE_QUERY)
+  const isMobile = useIsMobile()
   const [sidebarOpen, setSidebarOpen] = useState(false)
 
   return (

--- a/glancy-site/src/components/Sidebar/Sidebar.jsx
+++ b/glancy-site/src/components/Sidebar/Sidebar.jsx
@@ -1,9 +1,7 @@
 import Brand from '@/components/Brand'
 import SidebarFunctions from './SidebarFunctions.jsx'
 import SidebarUser from './SidebarUser.jsx'
-import useMediaQuery from '@/hooks/useMediaQuery.js'
-
-const MOBILE_QUERY = '(max-width: 600px)'
+import { useIsMobile } from '@/utils/index.js'
 
 function Sidebar({
   isMobile: mobileProp,
@@ -12,7 +10,7 @@ function Sidebar({
   onToggleFavorites,
   onSelectHistory
 }) {
-  const defaultMobile = useMediaQuery(MOBILE_QUERY)
+  const defaultMobile = useIsMobile()
   const isMobile = mobileProp ?? defaultMobile
   return (
     <>

--- a/glancy-site/src/components/form/EditableField/EditableField.jsx
+++ b/glancy-site/src/components/form/EditableField/EditableField.jsx
@@ -19,7 +19,7 @@ function EditableField({
 
   const containerCls = [styles.field, className].filter(Boolean).join(' ')
   const inputCls = [styles.input, inputClassName].filter(Boolean).join(' ')
-  const btnCls = [styles.edit-btn, buttonClassName].filter(Boolean).join(' ')
+  const btnCls = [styles['edit-btn'], buttonClassName].filter(Boolean).join(' ')
 
   const enableEdit = () => setEditing(true)
 


### PR DESCRIPTION
### Summary
- replace per-component media query logic with shared `useIsMobile` hook in Layout and Sidebar
- correct EditableField button style access to satisfy lint rules

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_68923483ac8c83329700863528fc22ea