### PR TITLE
[feature] extract favorites view and shortcuts hook

### DIFF
--- a/glancy-site/src/components/form/EditableField/EditableField.jsx
+++ b/glancy-site/src/components/form/EditableField/EditableField.jsx
@@ -19,7 +19,7 @@ function EditableField({
 
   const containerCls = [styles.field, className].filter(Boolean).join(' ')
   const inputCls = [styles.input, inputClassName].filter(Boolean).join(' ')
-  const btnCls = [styles.edit-btn, buttonClassName].filter(Boolean).join(' ')
+  const btnCls = [styles['edit-btn'], buttonClassName].filter(Boolean).join(' ')
 
   const enableEdit = () => setEditing(true)
 

--- a/glancy-site/src/hooks/useAppShortcuts.js
+++ b/glancy-site/src/hooks/useAppShortcuts.js
@@ -1,0 +1,88 @@
+import { useEffect, useCallback } from 'react'
+import translations from '@/i18n/index.js'
+
+export function useAppShortcuts({
+  inputRef,
+  lang,
+  setLang,
+  theme,
+  setTheme,
+  entry,
+  showFavorites,
+  showHistory,
+  toggleFavorite
+}) {
+  const focusInput = useCallback(() => {
+    inputRef.current?.focus()
+  }, [inputRef])
+
+  const cycleLanguage = useCallback(() => {
+    const langs = Object.keys(translations)
+    const next = langs[(langs.indexOf(lang) + 1) % langs.length]
+    setLang(next)
+  }, [lang, setLang])
+
+  const cycleTheme = useCallback(() => {
+    const seq = { dark: 'light', light: 'system', system: 'dark' }
+    setTheme(seq[theme] || 'light')
+  }, [theme, setTheme])
+
+  const toggleFavoriteEntry = useCallback(() => {
+    if (entry && !showFavorites && !showHistory) {
+      toggleFavorite(entry.term)
+    }
+  }, [entry, showFavorites, showHistory, toggleFavorite])
+
+  const openShortcuts = useCallback(() => {
+    document.dispatchEvent(new Event('open-shortcuts'))
+  }, [])
+
+  useEffect(() => {
+    function handleShortcut(e) {
+      const platform =
+        navigator.userAgentData?.platform || navigator.platform || ''
+      const mod = /Mac|iPhone|iPod|iPad/i.test(platform) ? e.metaKey : e.ctrlKey
+      if (!mod || !e.shiftKey) return
+      switch (e.key.toLowerCase()) {
+        case 'f':
+          e.preventDefault()
+          focusInput()
+          break
+        case 'l':
+          e.preventDefault()
+          cycleLanguage()
+          break
+        case 'm':
+          e.preventDefault()
+          cycleTheme()
+          break
+        case 'b':
+          e.preventDefault()
+          toggleFavoriteEntry()
+          break
+        case 'k':
+          e.preventDefault()
+          openShortcuts()
+          break
+        default:
+          break
+      }
+    }
+    document.addEventListener('keydown', handleShortcut)
+    return () => document.removeEventListener('keydown', handleShortcut)
+  }, [
+    focusInput,
+    cycleLanguage,
+    cycleTheme,
+    toggleFavoriteEntry,
+    openShortcuts
+  ])
+
+  return {
+    focusInput,
+    cycleLanguage,
+    cycleTheme,
+    toggleFavoriteEntry,
+    openShortcuts
+  }
+}

--- a/glancy-site/src/pages/App/FavoritesView.jsx
+++ b/glancy-site/src/pages/App/FavoritesView.jsx
@@ -1,0 +1,40 @@
+import ListItem from '@/components/ui/ListItem/ListItem.jsx'
+
+function FavoritesView({ favorites = [], onSelect, onUnfavorite, emptyMessage }) {
+  if (!favorites.length) {
+    return (
+      <div className="display-content">
+        <div className="display-term">{emptyMessage}</div>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="favorites-grid-display">
+      {favorites.map((w, i) => (
+        <ListItem
+          key={i}
+          className="favorite-item"
+          text={w}
+          textClassName="favorite-term"
+          onClick={() => onSelect?.(w)}
+          actions={(
+            <button
+              type="button"
+              aria-label="unfavorite"
+              className="unfavorite-btn"
+              onClick={(e) => {
+                e.stopPropagation()
+                onUnfavorite?.(w)
+              }}
+            >
+              ○
+            </button>
+          )}
+        />
+      ))}
+    </ul>
+  )
+}
+
+export default FavoritesView


### PR DESCRIPTION
### Summary
- Modularize favorites rendering with `FavoritesView` and move shortcut handling into `useAppShortcuts`.
- Streamline `App` by leveraging the new hook and component.
- Fix `EditableField` CSS module reference to satisfy lint.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6892347bfed88332b3810cb37c10b49a