### PR TITLE
[refactor] unify escape key handling

### DIFF
--- a/glancy-site/src/components/form/EditableField/EditableField.jsx
+++ b/glancy-site/src/components/form/EditableField/EditableField.jsx
@@ -19,7 +19,7 @@ function EditableField({
 
   const containerCls = [styles.field, className].filter(Boolean).join(' ')
   const inputCls = [styles.input, inputClassName].filter(Boolean).join(' ')
-  const btnCls = [styles.edit-btn, buttonClassName].filter(Boolean).join(' ')
+  const btnCls = [styles['edit-btn'], buttonClassName].filter(Boolean).join(' ')
 
   const enableEdit = () => setEditing(true)
 

--- a/glancy-site/src/components/modals/Modal.jsx
+++ b/glancy-site/src/components/modals/Modal.jsx
@@ -1,14 +1,8 @@
-import { useEffect } from 'react'
 import styles from './Modal.module.css'
+import useEscapeKey from '@/hooks/useEscapeKey.js'
 
 function Modal({ onClose, className = '', children }) {
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+  useEscapeKey(onClose)
 
   return (
     <div className={styles.overlay} onClick={onClose}>

--- a/glancy-site/src/components/ui/MessagePopup.jsx
+++ b/glancy-site/src/components/ui/MessagePopup.jsx
@@ -1,15 +1,8 @@
-import { useEffect } from 'react'
 import styles from './MessagePopup.module.css'
+import useEscapeKey from '@/hooks/useEscapeKey.js'
 
 function MessagePopup({ open, message, onClose }) {
-  useEffect(() => {
-    if (!open) return undefined
-    const onKeyDown = (e) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [open, onClose])
+  useEscapeKey(onClose, open)
 
   if (!open) return null
   return (

--- a/glancy-site/src/hooks/useEscapeKey.js
+++ b/glancy-site/src/hooks/useEscapeKey.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react'
+
+export default function useEscapeKey(handler, active = true) {
+  useEffect(() => {
+    if (!active) return undefined
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') handler(e)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [handler, active])
+}
+


### PR DESCRIPTION
### Summary
- Extract reusable `useEscapeKey` hook and apply it to modal and popup components.
- Fix EditableField class reference for lint compliance.

### Testing
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_689234c302288332a3f3a14f09274e0c