### PR TITLE
[refactor] use persistent model store

### DIFF
--- a/glancy-site/src/store/__tests__/modelStore.test.js
+++ b/glancy-site/src/store/__tests__/modelStore.test.js
@@ -7,6 +7,7 @@ describe('modelStore', () => {
   test('setModel updates state and storage', () => {
     act(() => useModelStore.getState().setModel('GPT'))
     expect(useModelStore.getState().model).toBe('GPT')
-    expect(localStorage.getItem('dictionaryModel')).toBe('GPT')
+    const stored = JSON.parse(localStorage.getItem('dictionaryModel'))
+    expect(stored.state.model).toBe('GPT')
   })
 })

--- a/glancy-site/src/store/modelStore.ts
+++ b/glancy-site/src/store/modelStore.ts
@@ -1,20 +1,19 @@
-import { create } from 'zustand'
+import { createPersistentStore } from './createPersistentStore.ts'
 
 interface ModelState {
   model: string
   setModel: (value: string) => void
 }
 
-const STORAGE_KEY = 'dictionaryModel'
-
-export const useModelStore = create<ModelState>((set) => {
-  const stored = localStorage.getItem(STORAGE_KEY)
-  const initial = stored || 'DEEPSEEK'
-  return {
-    model: initial,
+export const useModelStore = createPersistentStore<ModelState>({
+  key: 'dictionaryModel',
+  initializer: (set) => ({
+    model: 'DEEPSEEK',
     setModel: (value: string) => {
-      localStorage.setItem(STORAGE_KEY, value)
       set({ model: value })
     }
+  }),
+  persistOptions: {
+    partialize: (state) => ({ model: state.model })
   }
 })


### PR DESCRIPTION
### Summary
- refactor model store to use shared persistent store helper
- update model store unit test for JSON-based persistence

### Testing
- `npm run lint` -> ✅
- `npm run build` -> ✅
- `npm test` -> ❌ (TypeError: api.jsonRequest is not a function; process out of memory)
- `npm test src/store/__tests__/modelStore.test.js` -> ✅


------
https://chatgpt.com/codex/tasks/task_e_6892383dd12c8332a533a8b069f238e3