### PR TITLE
[feature] add stopPropagation helper

### DIFF
--- a/glancy-site/src/components/modals/Modal.jsx
+++ b/glancy-site/src/components/modals/Modal.jsx
@@ -1,12 +1,13 @@
 import styles from './Modal.module.css'
 import useEscapeKey from '@/hooks/useEscapeKey.js'
+import { withStopPropagation } from '@/utils/stopPropagation.js'
 
 function Modal({ onClose, className = '', children }) {
   useEscapeKey(onClose)
 
   return (
     <div className={styles.overlay} onClick={onClose}>
-      <div className={className} onClick={(e) => e.stopPropagation()}>
+      <div className={className} onClick={withStopPropagation()}>
         {children}
       </div>
     </div>

--- a/glancy-site/src/components/ui/ItemMenu/ItemMenu.jsx
+++ b/glancy-site/src/components/ui/ItemMenu/ItemMenu.jsx
@@ -1,5 +1,6 @@
 import ThemeIcon from '@/components/ui/Icon'
 import useOutsideToggle from '@/hooks/useOutsideToggle.js'
+import { withStopPropagation } from '@/utils/stopPropagation.js'
 import styles from './ItemMenu.module.css'
 
 function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
@@ -10,10 +11,9 @@ function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
       <button
         type="button"
         className={styles.action}
-        onClick={(e) => {
-          e.stopPropagation()
+        onClick={withStopPropagation(() => {
           setOpen(!open)
-        }}
+        })}
       >
         <ThemeIcon name="ellipsis-vertical" width={16} height={16} />
       </button>
@@ -21,11 +21,10 @@ function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
         <div className={styles.menu}>
           <button
             type="button"
-            onClick={(e) => {
-              e.stopPropagation()
+            onClick={withStopPropagation(() => {
               onFavorite()
               setOpen(false)
-            }}
+            })}
           >
             <ThemeIcon
               name="star-solid"
@@ -38,11 +37,10 @@ function ItemMenu({ onFavorite, onDelete, favoriteLabel, deleteLabel }) {
           <button
             type="button"
             className={styles['delete-btn']}
-            onClick={(e) => {
-              e.stopPropagation()
+            onClick={withStopPropagation(() => {
               onDelete()
               setOpen(false)
-            }}
+            })}
           >
             <ThemeIcon
               name="trash"

--- a/glancy-site/src/components/ui/MessagePopup.jsx
+++ b/glancy-site/src/components/ui/MessagePopup.jsx
@@ -1,5 +1,6 @@
 import styles from './MessagePopup.module.css'
 import useEscapeKey from '@/hooks/useEscapeKey.js'
+import { withStopPropagation } from '@/utils/stopPropagation.js'
 
 function MessagePopup({ open, message, onClose }) {
   useEscapeKey(onClose, open)
@@ -7,7 +8,7 @@ function MessagePopup({ open, message, onClose }) {
   if (!open) return null
   return (
     <div className={styles['popup-overlay']} onClick={onClose}>
-      <div className={styles.popup} onClick={(e) => e.stopPropagation()}>
+      <div className={styles.popup} onClick={withStopPropagation()}>
         <div>{message}</div>
         <button
           type="button"

--- a/glancy-site/src/utils/index.js
+++ b/glancy-site/src/utils/index.js
@@ -1,6 +1,7 @@
 export { extractMessage, safeJSONParse } from './json.js'
 export { getModifierKey, useIsMobile } from './device.js'
 export { isPresignedUrl, cacheBust } from './url.js'
+export { withStopPropagation } from './stopPropagation.js'
 
 export function detectWordLanguage(text) {
   return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'

--- a/glancy-site/src/utils/stopPropagation.js
+++ b/glancy-site/src/utils/stopPropagation.js
@@ -1,0 +1,6 @@
+export function withStopPropagation(handler = () => {}) {
+  return function (event, ...args) {
+    event.stopPropagation()
+    return handler(event, ...args)
+  }
+}


### PR DESCRIPTION
### Summary
- Introduced reusable withStopPropagation utility and exported through utils index
- Applied helper to Modal, ItemMenu, and MessagePopup components to cleanly stop event bubbling

### Testing
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_68923a23f7e883328da32b66dea5ab5c