### PR TITLE
[refactor] extract common modal content style

### DIFF
--- a/glancy-site/src/components/modals/HelpModal.jsx
+++ b/glancy-site/src/components/modals/HelpModal.jsx
@@ -4,7 +4,11 @@ import styles from './HelpModal.module.css'
 
 function HelpModal({ open, onClose }) {
   return (
-    <BaseModal open={open} onClose={onClose} className={styles['help-modal']}>
+    <BaseModal
+      open={open}
+      onClose={onClose}
+      className={`modal-content ${styles['help-modal']}`}
+    >
       <Faq />
     </BaseModal>
   )

--- a/glancy-site/src/components/modals/HelpModal.module.css
+++ b/glancy-site/src/components/modals/HelpModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .help-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
   max-width: 600px;
   width: 90%;
   max-height: 90vh;

--- a/glancy-site/src/components/modals/LogoutConfirmModal.jsx
+++ b/glancy-site/src/components/modals/LogoutConfirmModal.jsx
@@ -6,7 +6,11 @@ function LogoutConfirmModal({ open, onConfirm, onCancel, email }) {
   const { t } = useLanguage()
   const message = t.logoutConfirmMessage.replace('{email}', email)
   return (
-    <BaseModal open={open} onClose={onCancel} className={styles['logout-modal']}>
+    <BaseModal
+      open={open}
+      onClose={onCancel}
+      className={`modal-content ${styles['logout-modal']}`}
+    >
       <h3>{t.logoutConfirmTitle}</h3>
       <p className={styles.message}>{message}</p>
       <div className={styles.actions}>

--- a/glancy-site/src/components/modals/LogoutConfirmModal.module.css
+++ b/glancy-site/src/components/modals/LogoutConfirmModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .logout-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: var(--radius-md);
   width: 320px;
   max-width: 90%;
   text-align: center;

--- a/glancy-site/src/components/modals/ModalContent.module.css
+++ b/glancy-site/src/components/modals/ModalContent.module.css
@@ -1,0 +1,6 @@
+:global(.modal-content) {
+  background: var(--app-bg);
+  color: var(--app-color);
+  padding: 20px;
+  border-radius: var(--radius-md);
+}

--- a/glancy-site/src/components/modals/PaymentModal.jsx
+++ b/glancy-site/src/components/modals/PaymentModal.jsx
@@ -5,7 +5,11 @@ import { useLanguage } from '@/context/LanguageContext.jsx'
 function PaymentModal({ open, onClose }) {
   const { t } = useLanguage()
   return (
-    <BaseModal open={open} onClose={onClose} className={styles['payment-modal']}>
+    <BaseModal
+      open={open}
+      onClose={onClose}
+      className={`modal-content ${styles['payment-modal']}`}
+    >
       <h3>{t.paymentTitle}</h3>
       <div className={styles.methods}>
         <button type="button">{t.alipay}</button>

--- a/glancy-site/src/components/modals/PaymentModal.module.css
+++ b/glancy-site/src/components/modals/PaymentModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .payment-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
   width: 300px;
   max-width: 90%;
   text-align: center;

--- a/glancy-site/src/components/modals/ProfileModal.jsx
+++ b/glancy-site/src/components/modals/ProfileModal.jsx
@@ -4,7 +4,11 @@ import styles from './ProfileModal.module.css'
 
 function ProfileModal({ open, onClose }) {
   return (
-    <BaseModal open={open} onClose={onClose} className={styles['profile-modal']}>
+    <BaseModal
+      open={open}
+      onClose={onClose}
+      className={`modal-content ${styles['profile-modal']}`}
+    >
       <Profile onCancel={onClose} />
     </BaseModal>
   )

--- a/glancy-site/src/components/modals/ProfileModal.module.css
+++ b/glancy-site/src/components/modals/ProfileModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .profile-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
   max-width: 400px;
   width: 90%;
   max-height: 90vh;

--- a/glancy-site/src/components/modals/SettingsModal.jsx
+++ b/glancy-site/src/components/modals/SettingsModal.jsx
@@ -4,7 +4,11 @@ import styles from './SettingsModal.module.css'
 
 function SettingsModal({ open, onClose }) {
   return (
-    <BaseModal open={open} onClose={onClose} className={styles['auth-modal']}>
+    <BaseModal
+      open={open}
+      onClose={onClose}
+      className={`modal-content ${styles['auth-modal']}`}
+    >
       <Preferences />
     </BaseModal>
   )

--- a/glancy-site/src/components/modals/SettingsModal.module.css
+++ b/glancy-site/src/components/modals/SettingsModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .auth-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
   max-width: 400px;
   width: 90%;
   max-height: 90vh;
@@ -11,7 +9,6 @@
   flex-direction: column;
   align-items: center;
 }
-
 
 .auth-modal .app {
   width: 100%;
@@ -46,4 +43,3 @@
 .auth-modal button[type='submit'] {
   width: 100%;
 }
-

--- a/glancy-site/src/components/modals/ShortcutsModal.jsx
+++ b/glancy-site/src/components/modals/ShortcutsModal.jsx
@@ -15,7 +15,11 @@ function ShortcutsModal({ open, onClose }) {
   ]
 
   return (
-    <BaseModal open={open} onClose={onClose} className={styles['shortcuts-modal']}>
+    <BaseModal
+      open={open}
+      onClose={onClose}
+      className={`modal-content ${styles['shortcuts-modal']}`}
+    >
       <h3>{t.shortcutsTitle}</h3>
       <ul>
         {shortcuts.map((s) => (

--- a/glancy-site/src/components/modals/ShortcutsModal.module.css
+++ b/glancy-site/src/components/modals/ShortcutsModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .shortcuts-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
   width: 400px;
   max-width: 90%;
 }

--- a/glancy-site/src/components/modals/UpgradeModal.jsx
+++ b/glancy-site/src/components/modals/UpgradeModal.jsx
@@ -36,7 +36,7 @@ function UpgradeModal({ open, onClose }) {
   }
 
   return (
-    <Modal onClose={onClose} className={styles['upgrade-modal']}>
+    <Modal onClose={onClose} className={`modal-content ${styles['upgrade-modal']}`}>
       <h3>{t.choosePlan}</h3>
       <div className={styles.plans}>
         {plans.map((p) => (

--- a/glancy-site/src/components/modals/UpgradeModal.module.css
+++ b/glancy-site/src/components/modals/UpgradeModal.module.css
@@ -1,8 +1,6 @@
+@import url('./ModalContent.module.css');
+
 .upgrade-modal {
-  background: var(--app-bg);
-  color: var(--app-color);
-  padding: 20px;
-  border-radius: 8px;
   width: 320px;
   max-width: 90%;
 }
@@ -20,8 +18,6 @@
   border-radius: 6px;
   cursor: pointer;
 }
-
-
 
 .plan.current {
   /* highlight current plan using custom black */


### PR DESCRIPTION
### Summary
- extract shared modal content styles into a reusable module
- refactor modal components to apply the unified `modal-content` wrapper

### Testing
- `npm run lint` ✅
- `npm run lint:css` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68923a1b594c8332bcf296d9e885722c