### PR TITLE
[feature] enable @ alias for CSS imports

### DIFF
--- a/glancy-site/package-lock.json
+++ b/glancy-site/package-lock.json
@@ -29,6 +29,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.0.5",
         "jest-environment-jsdom": "^30.0.5",
+        "postcss-import": "^16.1.1",
         "stylelint": "^16.22.0",
         "stylelint-config-standard": "^38.0.0",
         "typescript": "^5.4.5",
@@ -5640,6 +5641,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7311,6 +7328,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -7375,6 +7399,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pirates": {
@@ -7483,6 +7517,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+      "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-resolve-nested-selector": {
@@ -7748,6 +7800,16 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7780,6 +7842,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -8539,6 +8622,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/svg-tags": {

--- a/glancy-site/package.json
+++ b/glancy-site/package.json
@@ -35,6 +35,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
+    "postcss-import": "^16.1.1",
     "stylelint": "^16.22.0",
     "stylelint-config-standard": "^38.0.0",
     "typescript": "^5.4.5",

--- a/glancy-site/src/components/form/AgeStepper/AgeStepper.module.css
+++ b/glancy-site/src/components/form/AgeStepper/AgeStepper.module.css
@@ -1,5 +1,5 @@
-@import url('../../../theme/colors.css');
-@import url('../../../theme/variables.css');
+@import url('@/theme/colors.css');
+@import url('@/theme/variables.css');
 
 .stepper {
   display: inline-flex;

--- a/glancy-site/src/components/form/GenderSelect/GenderSelect.module.css
+++ b/glancy-site/src/components/form/GenderSelect/GenderSelect.module.css
@@ -1,6 +1,6 @@
-@import url('../../../theme/colors.css');
-@import url('../../../theme/variables.css');
-@import url('../../../theme/spacing.css');
+@import url('@/theme/colors.css');
+@import url('@/theme/variables.css');
+@import url('@/theme/spacing.css');
 
 .group {
   display: flex;

--- a/glancy-site/src/components/ui/Button/Button.module.css
+++ b/glancy-site/src/components/ui/Button/Button.module.css
@@ -1,5 +1,5 @@
-@import url('../../../theme/colors.css');
-@import url('../../../theme/variables.css');
+@import url('@/theme/colors.css');
+@import url('@/theme/variables.css');
 
 .button {
   border-radius: var(--radius-md);

--- a/glancy-site/src/components/ui/ListItem/ListItem.module.css
+++ b/glancy-site/src/components/ui/ListItem/ListItem.module.css
@@ -1,5 +1,5 @@
-@import url('../../../theme/spacing.css');
-@import url('../../../theme/variables.css');
+@import url('@/theme/spacing.css');
+@import url('@/theme/variables.css');
 
 .item {
   display: flex;

--- a/glancy-site/src/styles/index.css
+++ b/glancy-site/src/styles/index.css
@@ -1,7 +1,7 @@
-@import url('../theme/colors.css');
-@import url("../theme/variables.css");
-@import url('../theme/spacing.css');
-@import url('../theme/typography.css');
+@import url('@/theme/colors.css');
+@import url('@/theme/variables.css');
+@import url('@/theme/spacing.css');
+@import url('@/theme/typography.css');
 
 :root {
   font-family: var(--font-family-base);

--- a/glancy-site/vite.config.js
+++ b/glancy-site/vite.config.js
@@ -1,13 +1,31 @@
 import { fileURLToPath, URL } from 'node:url'
+import path from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import postcssImport from 'postcss-import'
 
 // https://vite.dev/config/
+const srcDir = fileURLToPath(new URL('./src', import.meta.url))
+
 export default defineConfig({
   base: './',
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': srcDir
+    }
+  },
+  css: {
+    postcss: {
+      plugins: [
+        postcssImport({
+          resolve(id) {
+            if (id.startsWith('@/')) {
+              return path.resolve(srcDir, id.slice(2))
+            }
+            return undefined
+          }
+        })
+      ]
     }
   },
   plugins: [react()],


### PR DESCRIPTION
### Summary
- Configure Vite/PostCSS to resolve the `@` alias for CSS.
- Replace theme imports with `@`-based paths across styles.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run lint:css` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_68923acaa0f083329d36bfbb183338c6