### PR TITLE
[refactor] unify API resource access via useApiResource hook

### DIFF
--- a/glancy-site/src/__tests__/Login.test.jsx
+++ b/glancy-site/src/__tests__/Login.test.jsx
@@ -5,14 +5,17 @@ import { jest } from '@jest/globals'
 import { API_PATHS } from '@/config/api.js'
 
 const mockSetUser = jest.fn()
-const mockRequest = jest.fn().mockResolvedValue({ id: '1', token: 't' })
+const mockJsonRequest = jest.fn().mockResolvedValue({ id: '1', token: 't' })
 const mockNavigate = jest.fn()
 
 jest.unstable_mockModule('@/context/AppContext.jsx', () => ({
   useUser: () => ({ setUser: mockSetUser })
 }))
-jest.unstable_mockModule('@/hooks/useApi.js', () => ({
-  useApi: () => ({ request: mockRequest })
+jest.unstable_mockModule('@/hooks/useApiResource.js', () => ({
+  useApiResource: (resource) => {
+    if (resource === 'jsonRequest') return mockJsonRequest
+    return () => {}
+  }
 }))
 jest.unstable_mockModule('@/context/ThemeContext.jsx', () => ({
   useTheme: () => ({ resolvedTheme: 'light' })
@@ -39,8 +42,8 @@ test('logs in and navigates home', async () => {
     target: { value: 'pass' }
   })
   fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-  await waitFor(() => expect(mockRequest).toHaveBeenCalled())
-  expect(mockRequest).toHaveBeenCalledWith(API_PATHS.login, expect.any(Object))
+  await waitFor(() => expect(mockJsonRequest).toHaveBeenCalled())
+  expect(mockJsonRequest).toHaveBeenCalledWith(API_PATHS.login, expect.any(Object))
   await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith({ id: '1', token: 't' }))
   expect(mockNavigate).toHaveBeenCalledWith('/')
 })

--- a/glancy-site/src/__tests__/Preferences.test.jsx
+++ b/glancy-site/src/__tests__/Preferences.test.jsx
@@ -5,6 +5,7 @@ import { jest } from '@jest/globals'
 import { API_PATHS } from '@/config/api.js'
 
 const mockRequest = jest.fn().mockResolvedValue({})
+const mockJsonRequest = jest.fn().mockResolvedValue({})
 const mockFetchModels = jest.fn().mockResolvedValue(['M1'])
 const mockSetTheme = jest.fn()
 const mockSetModel = jest.fn()
@@ -32,8 +33,13 @@ jest.unstable_mockModule('@/context/ThemeContext.jsx', () => ({
 jest.unstable_mockModule('@/context/AppContext.jsx', () => ({
   useUser: () => ({ user: { id: '1', token: 't' } })
 }))
-jest.unstable_mockModule('@/hooks/useApi.js', () => ({
-  useApi: () => ({ request: mockRequest, llm: { fetchModels: mockFetchModels } })
+jest.unstable_mockModule('@/hooks/useApiResource.js', () => ({
+  useApiResource: (resource) => {
+    if (resource === 'request') return mockRequest
+    if (resource === 'jsonRequest') return mockJsonRequest
+    if (resource === 'llm') return { fetchModels: mockFetchModels }
+    return {}
+  }
 }))
 jest.unstable_mockModule('@/store/modelStore.ts', () => ({
   useModelStore: () => ({ model: 'M1', setModel: mockSetModel })
@@ -48,8 +54,9 @@ beforeEach(() => {
 test('saves preferences via api', async () => {
   render(<Preferences />)
   await waitFor(() => expect(mockFetchModels).toHaveBeenCalled())
+  await waitFor(() => expect(mockRequest).toHaveBeenCalled())
   fireEvent.change(screen.getByLabelText('Language'), { target: { value: 'CHINESE' } })
   fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-  await waitFor(() => expect(mockRequest).toHaveBeenCalled())
+  await waitFor(() => expect(mockJsonRequest).toHaveBeenCalled())
   expect(mockRequest.mock.calls[0][0]).toBe(`${API_PATHS.preferences}/user/1`)
 })

--- a/glancy-site/src/__tests__/Register.test.jsx
+++ b/glancy-site/src/__tests__/Register.test.jsx
@@ -5,7 +5,7 @@ import { jest } from '@jest/globals'
 import { API_PATHS } from '@/config/api.js'
 
 const mockSetUser = jest.fn()
-const mockRequest = jest
+const mockJsonRequest = jest
   .fn()
   .mockResolvedValueOnce(undefined)
   .mockResolvedValueOnce({ id: '1', token: 't' })
@@ -14,8 +14,11 @@ const mockNavigate = jest.fn()
 jest.unstable_mockModule('@/context/AppContext.jsx', () => ({
   useUser: () => ({ setUser: mockSetUser })
 }))
-jest.unstable_mockModule('@/hooks/useApi.js', () => ({
-  useApi: () => ({ request: mockRequest })
+jest.unstable_mockModule('@/hooks/useApiResource.js', () => ({
+  useApiResource: (resource) => {
+    if (resource === 'jsonRequest') return mockJsonRequest
+    return () => {}
+  }
 }))
 jest.unstable_mockModule('@/context/ThemeContext.jsx', () => ({
   useTheme: () => ({ resolvedTheme: 'light' })
@@ -42,9 +45,9 @@ test('registers and logs in user', async () => {
     target: { value: '0000' }
   })
   fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
-  await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2))
-  expect(mockRequest.mock.calls[0][0]).toBe(API_PATHS.register)
-  expect(mockRequest.mock.calls[1][0]).toBe(API_PATHS.login)
+  await waitFor(() => expect(mockJsonRequest).toHaveBeenCalledTimes(2))
+  expect(mockJsonRequest.mock.calls[0][0]).toBe(API_PATHS.register)
+  expect(mockJsonRequest.mock.calls[1][0]).toBe(API_PATHS.login)
   await waitFor(() => expect(mockSetUser).toHaveBeenCalledWith({ id: '1', token: 't' }))
   expect(mockNavigate).toHaveBeenCalledWith('/')
 })

--- a/glancy-site/src/api/chat.js
+++ b/glancy-site/src/api/chat.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest, createJsonRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 export function createChatApi(request = apiRequest) {
   const jsonRequest = createJsonRequest(request)
@@ -14,7 +13,3 @@ export function createChatApi(request = apiRequest) {
 }
 
 export const { sendChatMessage } = createChatApi()
-
-export function useChatApi() {
-  return useApi().chat
-}

--- a/glancy-site/src/api/llm.js
+++ b/glancy-site/src/api/llm.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 export function createLlmApi(request = apiRequest) {
   const fetchModels = async () => request(API_PATHS.llmModels)
@@ -8,7 +7,3 @@ export function createLlmApi(request = apiRequest) {
 }
 
 export const { fetchModels } = createLlmApi()
-
-export function useLlmApi() {
-  return useApi().llm
-}

--- a/glancy-site/src/api/locale.js
+++ b/glancy-site/src/api/locale.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 export function createLocaleApi(request = apiRequest) {
   const getLocale = () => request(API_PATHS.locale)
@@ -8,7 +7,3 @@ export function createLocaleApi(request = apiRequest) {
 }
 
 export const { getLocale } = createLocaleApi()
-
-export function useLocaleApi() {
-  return useApi().locale
-}

--- a/glancy-site/src/api/profiles.js
+++ b/glancy-site/src/api/profiles.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest, createJsonRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 export function createProfilesApi(request = apiRequest) {
   const jsonRequest = createJsonRequest(request)
@@ -18,7 +17,3 @@ export function createProfilesApi(request = apiRequest) {
 }
 
 export const { fetchProfile, saveProfile } = createProfilesApi()
-
-export function useProfilesApi() {
-  return useApi().profiles
-}

--- a/glancy-site/src/api/searchRecords.js
+++ b/glancy-site/src/api/searchRecords.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest, createJsonRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 export function createSearchRecordsApi(request = apiRequest) {
   const jsonRequest = createJsonRequest(request)
@@ -62,7 +61,3 @@ export const {
   favoriteSearchRecord,
   unfavoriteSearchRecord
 } = createSearchRecordsApi()
-
-export function useSearchRecordsApi() {
-  return useApi().searchRecords
-}

--- a/glancy-site/src/api/users.js
+++ b/glancy-site/src/api/users.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 export function createUsersApi(request = apiRequest) {
   const uploadAvatar = async ({ userId, file, token }) => {
@@ -17,7 +16,3 @@ export function createUsersApi(request = apiRequest) {
 }
 
 export const { uploadAvatar } = createUsersApi()
-
-export function useUsersApi() {
-  return useApi().users
-}

--- a/glancy-site/src/api/words.js
+++ b/glancy-site/src/api/words.js
@@ -1,6 +1,5 @@
 import { API_PATHS } from '@/config/api.js'
 import { apiRequest } from './client.js'
-import { useApi } from '@/hooks/useApi.js'
 
 /**
  * Query a word definition
@@ -27,7 +26,3 @@ export function createWordsApi(request = apiRequest) {
 }
 
 export const { fetchWord, fetchWordAudio } = createWordsApi()
-
-export function useWordsApi() {
-  return useApi().words
-}

--- a/glancy-site/src/components/Toolbar/ModelSelector.jsx
+++ b/glancy-site/src/components/Toolbar/ModelSelector.jsx
@@ -3,21 +3,20 @@ import styles from './Toolbar.module.css'
 import { useLanguage } from '@/context/LanguageContext.jsx'
 import useOutsideToggle from '@/hooks/useOutsideToggle.js'
 import { useModelStore } from '@/store/modelStore.ts'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 
 function ModelSelector() {
   const { open, setOpen, ref: menuRef } = useOutsideToggle(false)
   const { model, setModel } = useModelStore()
   const [models, setModels] = useState([])
   const { t } = useLanguage()
-  const api = useApi()
+  const { fetchModels } = useApiResource('llm')
 
   useEffect(() => {
-    api.llm
-      .fetchModels()
+    fetchModels()
       .then((list) => setModels(list))
       .catch((err) => console.error(err))
-  }, [api])
+  }, [fetchModels])
 
   const selectModel = (value) => {
     setModel(value)

--- a/glancy-site/src/context/LocaleContext.jsx
+++ b/glancy-site/src/context/LocaleContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 
 const LocaleContext = createContext({
   locale: null,
@@ -11,11 +11,11 @@ export function LocaleProvider({ children }) {
     const stored = localStorage.getItem('locale')
     return stored ? JSON.parse(stored) : null
   })
-  const api = useApi()
+  const { getLocale } = useApiResource('locale')
 
   useEffect(() => {
     if (locale) return
-    api.locale.getLocale()
+    getLocale()
       .then((data) => {
         setLocale(data)
         localStorage.setItem('locale', JSON.stringify(data))
@@ -23,7 +23,7 @@ export function LocaleProvider({ children }) {
       .catch((err) => {
         console.error(err)
       })
-  }, [locale, api])
+  }, [locale, getLocale])
 
   return (
     <LocaleContext.Provider value={{ locale, setLocale }}>

--- a/glancy-site/src/hooks/useApiResource.js
+++ b/glancy-site/src/hooks/useApiResource.js
@@ -1,0 +1,5 @@
+import { useApi } from '@/hooks/useApi.js'
+
+export function useApiResource(resource) {
+  return useApi()[resource]
+}

--- a/glancy-site/src/hooks/useFetchWord.js
+++ b/glancy-site/src/hooks/useFetchWord.js
@@ -1,9 +1,8 @@
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 import { detectWordLanguage, clientNameFromModel } from '@/utils/index.js'
 
 export function useFetchWord() {
-  const api = useApi()
-  const { fetchWord } = api.words
+  const { fetchWord } = useApiResource('words')
 
   const fetchWordWithHandling = async ({ user, term, model }) => {
     const language = detectWordLanguage(term)

--- a/glancy-site/src/pages/auth/Login/index.jsx
+++ b/glancy-site/src/pages/auth/Login/index.jsx
@@ -2,17 +2,17 @@ import { useNavigate } from 'react-router-dom'
 import { AuthForm } from '@/components'
 import { API_PATHS } from '@/config/api.js'
 import { useUser } from '@/context/AppContext.jsx'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 import { useLanguage } from '@/context/LanguageContext.jsx'
 
 function Login() {
   const { setUser } = useUser()
-  const api = useApi()
+  const jsonRequest = useApiResource('jsonRequest')
   const navigate = useNavigate()
   const { t } = useLanguage()
 
   const handleLogin = async ({ account, password, method }) => {
-    const data = await api.jsonRequest(API_PATHS.login, {
+    const data = await jsonRequest(API_PATHS.login, {
       method: 'POST',
       body: { account, password, method }
     })

--- a/glancy-site/src/pages/auth/Register/index.jsx
+++ b/glancy-site/src/pages/auth/Register/index.jsx
@@ -1,12 +1,12 @@
 import { useNavigate } from 'react-router-dom'
 import { AuthForm } from '@/components'
 import { API_PATHS } from '@/config/api.js'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 import { useUser } from '@/context/AppContext.jsx'
 import { useLanguage } from '@/context/LanguageContext.jsx'
 
 function Register() {
-  const api = useApi()
+  const jsonRequest = useApiResource('jsonRequest')
   const { setUser } = useUser()
   const navigate = useNavigate()
   const { t } = useLanguage()
@@ -22,14 +22,14 @@ function Register() {
   }
 
   const handleRegister = async ({ account, password, method }) => {
-    await api.jsonRequest(API_PATHS.register, {
+    await jsonRequest(API_PATHS.register, {
       method: 'POST',
       body: {
         [method]: account,
         code: password
       }
     })
-    const loginData = await api.jsonRequest(API_PATHS.login, {
+    const loginData = await jsonRequest(API_PATHS.login, {
       method: 'POST',
       body: { account, method, password }
     })

--- a/glancy-site/src/pages/faq/index.jsx
+++ b/glancy-site/src/pages/faq/index.jsx
@@ -2,25 +2,25 @@ import { useEffect, useState } from 'react'
 import '@/pages/App/App.css'
 import { useLanguage } from '@/context/LanguageContext.jsx'
 import { API_PATHS } from '@/config/api.js'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 import MessagePopup from '@/components/ui/MessagePopup.jsx'
 
 function Faq() {
   const { t } = useLanguage()
   const [items, setItems] = useState([])
-  const api = useApi()
+  const request = useApiResource('request')
   const [popupOpen, setPopupOpen] = useState(false)
   const [popupMsg, setPopupMsg] = useState('')
 
   useEffect(() => {
-    api.request(API_PATHS.faqs)
+    request(API_PATHS.faqs)
       .then((data) => setItems(data))
       .catch((err) => {
         console.error(err)
         setPopupMsg(t.fail)
         setPopupOpen(true)
       })
-  }, [api, t])
+  }, [request, t])
 
   return (
     <div className="app">

--- a/glancy-site/src/pages/preferences/index.jsx
+++ b/glancy-site/src/pages/preferences/index.jsx
@@ -6,15 +6,17 @@ import { useTheme } from '@/context/ThemeContext.jsx'
 import { useUser } from '@/context/AppContext.jsx'
 import { API_PATHS } from '@/config/api.js'
 import MessagePopup from '@/components/ui/MessagePopup.jsx'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 import { useModelStore } from '@/store/modelStore.ts'
 
 function Preferences() {
   const { t } = useLanguage()
   const { theme, setTheme } = useTheme()
   const { user } = useUser()
-  const api = useApi()
   const { model, setModel } = useModelStore()
+  const { fetchModels } = useApiResource('llm')
+  const request = useApiResource('request')
+  const jsonRequest = useApiResource('jsonRequest')
   const [models, setModels] = useState([])
   const [sourceLang, setSourceLang] = useState(
     localStorage.getItem('sourceLang') || 'auto'
@@ -27,15 +29,14 @@ function Preferences() {
   const [popupMsg, setPopupMsg] = useState('')
 
   useEffect(() => {
-    api.llm
-      .fetchModels()
+    fetchModels()
       .then((list) => setModels(list))
       .catch((err) => console.error(err))
-  }, [api])
+  }, [fetchModels])
 
   useEffect(() => {
     if (!user) return
-    api.request(`${API_PATHS.preferences}/user/${user.id}`)
+    request(`${API_PATHS.preferences}/user/${user.id}`)
       .then((data) => {
         const sl = data.systemLanguage || 'auto'
         const tl = data.searchLanguage || 'ENGLISH'
@@ -53,12 +54,12 @@ function Preferences() {
         setPopupMsg(t.fail)
         setPopupOpen(true)
       })
-  }, [setTheme, t, user, api, model, setModel])
+  }, [setTheme, t, user, request, model, setModel])
 
   const handleSave = async (e) => {
     e.preventDefault()
     if (!user) return
-    await api.jsonRequest(`${API_PATHS.preferences}/user/${user.id}`, {
+    await jsonRequest(`${API_PATHS.preferences}/user/${user.id}`, {
       method: 'POST',
       body: {
         systemLanguage: sourceLang,

--- a/glancy-site/src/pages/profile/index.jsx
+++ b/glancy-site/src/pages/profile/index.jsx
@@ -7,7 +7,7 @@ import MessagePopup from '@/components/ui/MessagePopup.jsx'
 import AgeStepper from '@/components/form/AgeStepper/AgeStepper.jsx'
 import GenderSelect from '@/components/form/GenderSelect/GenderSelect.jsx'
 import EditableField from '@/components/form/EditableField/EditableField.jsx'
-import { useApi } from '@/hooks/useApi.js'
+import { useApiResource } from '@/hooks/useApiResource.js'
 import { useUser } from '@/context/AppContext.jsx'
 import { cacheBust } from '@/utils/url.js'
 import ThemeIcon from '@/components/ui/Icon'
@@ -15,7 +15,8 @@ import ThemeIcon from '@/components/ui/Icon'
 function Profile({ onCancel }) {
   const { t } = useLanguage()
   const { user: currentUser, setUser } = useUser()
-  const api = useApi()
+  const { uploadAvatar } = useApiResource('users')
+  const { fetchProfile, saveProfile } = useApiResource('profiles')
   const [username, setUsername] = useState(currentUser?.username || '')
   const [email, setEmail] = useState(currentUser?.email || '')
   const [phone, setPhone] = useState(currentUser?.phone || '')
@@ -33,7 +34,7 @@ function Profile({ onCancel }) {
     const preview = URL.createObjectURL(file)
     setAvatar(preview)
     try {
-      const data = await api.users.uploadAvatar({
+      const data = await uploadAvatar({
         userId: currentUser.id,
         file,
         token: currentUser.token
@@ -52,8 +53,7 @@ function Profile({ onCancel }) {
 
   useEffect(() => {
     if (!currentUser) return
-    api.profiles
-      .fetchProfile({ userId: currentUser.id, token: currentUser.token })
+    fetchProfile({ userId: currentUser.id, token: currentUser.token })
       .then((data) => {
         setAge(data.age)
         setGender(data.gender)
@@ -69,12 +69,12 @@ function Profile({ onCancel }) {
         setPopupMsg(t.fail)
         setPopupOpen(true)
       })
-  }, [api, t, currentUser])
+  }, [fetchProfile, t, currentUser])
 
   const handleSave = async (e) => {
     e.preventDefault()
     if (!currentUser) return
-    await api.profiles.saveProfile({
+    await saveProfile({
       userId: currentUser.id,
       token: currentUser.token,
       profile: {


### PR DESCRIPTION
### Summary
- Introduced a generic `useApiResource` hook and removed redundant `useXxxApi` helpers for a consistent API surface.
- Refactored pages and tests to retrieve resources through the new hook, streamlining API consumption across the app.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ❌ (JavaScript heap out of memory)

### Notes
- Tests exceeded available heap space; rerun with increased Node memory if needed.

------
https://chatgpt.com/codex/tasks/task_e_68923a202bbc83328ff43e80f27f814e