### PR TITLE
[chore] remove duplicate lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 此仓库包含格律词典前端代码，采用 React + Vite 构建。
 
+## 开发环境
+所有前端代码位于 `glancy-site/` 目录。安装依赖时需先进入该目录：
+
+```bash
+cd glancy-site
+npm ci
+```
+
+后续的 lint、构建等脚本也在此目录执行。
+
 ## 部署方式
 
 通过 GitHub Actions 自动构建并将生成的静态文件同步到云服务器。你需要在仓库的 `Settings -> Secrets and variables -> Actions` 中设置以下几个 Secret：

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Glancy-site",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
### Summary
- remove redundant lockfile from repo root to rely on `glancy-site/package-lock.json`
- document that dependency installation should be run from the `glancy-site/` directory

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6892e6b0dc78833299011d1a4496ee12