### PR TITLE
[refactor] modularize language and model utilities

### DIFF
--- a/glancy-site/src/components/Layout/index.jsx
+++ b/glancy-site/src/components/Layout/index.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import Sidebar from '@/components/Sidebar'
 import DesktopTopBar from '@/components/TopBar/DesktopTopBar.jsx'
 import MobileTopBar from '@/components/TopBar/MobileTopBar.jsx'
-import { useIsMobile } from '@/utils/index.js'
+import { useIsMobile } from '@/utils'
 import styles from './Layout.module.css'
 
 function Layout({ children, sidebarProps = {}, topBarProps = {}, bottomContent = null }) {

--- a/glancy-site/src/components/Sidebar/Sidebar.jsx
+++ b/glancy-site/src/components/Sidebar/Sidebar.jsx
@@ -1,7 +1,7 @@
 import Brand from '@/components/Brand'
 import SidebarFunctions from './SidebarFunctions.jsx'
 import SidebarUser from './SidebarUser.jsx'
-import { useIsMobile } from '@/utils/index.js'
+import { useIsMobile } from '@/utils'
 
 function Sidebar({
   isMobile: mobileProp,

--- a/glancy-site/src/hooks/useFetchWord.js
+++ b/glancy-site/src/hooks/useFetchWord.js
@@ -1,5 +1,5 @@
 import { useApi } from '@/hooks/useApi.js'
-import { detectWordLanguage, clientNameFromModel } from '@/utils/index.js'
+import { detectWordLanguage, clientNameFromModel } from '@/utils'
 
 export function useFetchWord() {
   const api = useApi()

--- a/glancy-site/src/utils/index.js
+++ b/glancy-site/src/utils/index.js
@@ -2,11 +2,5 @@ export { extractMessage, safeJSONParse } from './json.js'
 export { getModifierKey, useIsMobile } from './device.js'
 export { isPresignedUrl, cacheBust } from './url.js'
 export { withStopPropagation } from './stopPropagation.js'
-
-export function detectWordLanguage(text) {
-  return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'
-}
-
-export function clientNameFromModel(model) {
-  return model ? model.toLowerCase().replace(/_.*/, '') : ''
-}
+export { detectWordLanguage } from './language.js'
+export { clientNameFromModel } from './model.js'

--- a/glancy-site/src/utils/language.js
+++ b/glancy-site/src/utils/language.js
@@ -1,0 +1,9 @@
+/**
+ * Detect the language of a text based on presence of Chinese characters.
+ * @param {string} text
+ * @returns {'CHINESE' | 'ENGLISH'}
+ */
+export function detectWordLanguage(text = '') {
+  return /[\u4e00-\u9fff]/u.test(text) ? 'CHINESE' : 'ENGLISH'
+}
+

--- a/glancy-site/src/utils/model.js
+++ b/glancy-site/src/utils/model.js
@@ -1,0 +1,10 @@
+/**
+ * Derive a client identifier from a model string.
+ * For example: "OPENAI_GPT3" -> "openai".
+ * @param {string} model
+ * @returns {string}
+ */
+export function clientNameFromModel(model = '') {
+  return model.toLowerCase().split('_')[0]
+}
+


### PR DESCRIPTION
### Summary
- split language detection and model mapping helpers into standalone utils and re-export through `@/utils`
- update hook and components to consume the new centralized utilities

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6892eb2a38f88332b8149d8c9a85ca72