### PR TITLE
[feature] centralize svg icon imports

### DIFF
--- a/glancy-site/src/assets/icons.js
+++ b/glancy-site/src/assets/icons.js
@@ -1,0 +1,27 @@
+/**
+ * Icon registry generated via `import.meta.glob`.
+ * Aggregates all SVG assets within the assets directory.
+ */
+
+const modules = import.meta.glob('./**/*.svg', {
+  eager: true,
+  import: 'default',
+})
+
+const icons = {}
+
+for (const [path, mod] of Object.entries(modules)) {
+  const filename = path.split('/').pop().replace('.svg', '')
+
+  if (filename.endsWith('-light')) {
+    const name = filename.replace('-light', '')
+    icons[name] = { ...(icons[name] || {}), light: mod }
+  } else if (filename.endsWith('-dark')) {
+    const name = filename.replace('-dark', '')
+    icons[name] = { ...(icons[name] || {}), dark: mod }
+  } else {
+    icons[filename] = { ...(icons[filename] || {}), single: mod }
+  }
+}
+
+export default icons

--- a/glancy-site/src/components/ui/Icon/index.jsx
+++ b/glancy-site/src/components/ui/Icon/index.jsx
@@ -1,38 +1,8 @@
 import React from 'react'
 import { useTheme } from '@/context'
+import ICONS from '@/assets/icons.js'
 
-// automatically import all svg assets and group them by theme
-// use relative paths instead of alias to ensure compatibility across build tools
-// NOTE: this file lives in `src/components/ui/Icon`, so we need to go up three levels
-// to reach `src/assets`. Keeping this explicit helps future refactors remain aware
-// of the relationship between components and shared assets.
-let modules = {}
-try {
-  modules = import.meta.glob('../../../assets/**/*.svg', {
-    eager: true,
-    import: 'default',
-  })
-} catch {
-  // ignore in environments without Vite's glob support
-}
-
-// shape: { [name]: { light?: url, dark?: url, single?: url } }
-const ICONS = {}
-
-for (const [path, mod] of Object.entries(modules)) {
-  const filename = path.split('/').pop().replace('.svg', '')
-
-  if (filename.endsWith('-light')) {
-    const name = filename.replace('-light', '')
-    ICONS[name] = { ...(ICONS[name] || {}), light: mod }
-  } else if (filename.endsWith('-dark')) {
-    const name = filename.replace('-dark', '')
-    ICONS[name] = { ...(ICONS[name] || {}), dark: mod }
-  } else {
-    const name = filename
-    ICONS[name] = { ...(ICONS[name] || {}), single: mod }
-  }
-}
+// ICONS shape: { [name]: { light?: url, dark?: url, single?: url } }
 
 export function ThemeIcon({ name, alt, ...props }) {
   const { resolvedTheme } = useTheme()

--- a/glancy-site/vite.config.js
+++ b/glancy-site/vite.config.js
@@ -4,23 +4,30 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import postcssImport from 'postcss-import'
 
-// https://vite.dev/config/
+// centralised directory references
 const srcDir = fileURLToPath(new URL('./src', import.meta.url))
+const assetsDir = fileURLToPath(new URL('./src/assets', import.meta.url))
+
+// alias map reused by both Vite and PostCSS
+const aliases = {
+  '@': srcDir,
+  '@assets': assetsDir
+}
 
 export default defineConfig({
   base: './',
   resolve: {
-    alias: {
-      '@': srcDir
-    }
+    alias: aliases
   },
   css: {
     postcss: {
       plugins: [
         postcssImport({
           resolve(id) {
-            if (id.startsWith('@/')) {
-              return path.resolve(srcDir, id.slice(2))
+            for (const [key, target] of Object.entries(aliases)) {
+              if (id.startsWith(`${key}/`)) {
+                return path.resolve(target, id.slice(key.length + 1))
+              }
             }
             return undefined
           }


### PR DESCRIPTION
### Summary
- centralize all SVG icons via a registry and consume it in the Icon component
- consolidate alias resolution for `@` and `@assets` in Vite config for cleaner imports

### Testing
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6892eb7357348332aac7acf13a86c9e8