### PR TITLE
[fix] improve sidebar item menu overlay

### DIFF
--- a/glancy-site/src/components/Sidebar/Sidebar.module.css
+++ b/glancy-site/src/components/Sidebar/Sidebar.module.css
@@ -56,14 +56,14 @@
 
 .sidebar-functions {
   flex: 1;
-  overflow-y: auto;
+  overflow: visible auto;
   display: flex;
   flex-direction: column;
 }
 
 .history-list {
   flex: 1;
-  overflow-y: auto;
+  overflow: visible auto;
 }
 
 .history-list li {
@@ -102,7 +102,7 @@ border-radius: 4px;
   list-style: none;
   padding: 0;
   margin: 0;
-  overflow-y: auto;
+  overflow: visible auto;
   flex: 1;
 }
 

--- a/glancy-site/src/components/ui/ItemMenu/ItemMenu.module.css
+++ b/glancy-site/src/components/ui/ItemMenu/ItemMenu.module.css
@@ -13,8 +13,9 @@
 
 .menu {
   position: absolute;
-  right: 0;
-  top: calc(100% + 4px);
+  left: calc(100% + 4px);
+  top: 50%;
+  transform: translateY(-50%);
   background: var(--sidebar-bg);
   color: var(--sidebar-color);
   border: 1px solid var(--border-color);

--- a/glancy-site/src/theme/variables.css
+++ b/glancy-site/src/theme/variables.css
@@ -6,5 +6,5 @@
   --btn-padding: 0.6em 1.2em;
   --btn-border: 1px solid transparent;
   --user-menu-width: 180px;
-  --z-index-popover: 1100;
+  --z-index-popover: 2000;
 }


### PR DESCRIPTION
### Summary
- Allow sidebar item menu to pop out horizontally and sit above other elements.
- Permit horizontal overflow in sidebar lists so menus are not clipped.

### Testing
- `npm run lint` ✅
- `npm run lint:css` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_6892ea8e60308332af0966f06ddd9b19