### PR TITLE
[feature] unify empty-state handling

### DIFF
--- a/glancy-site/src/components/ui/EmptyState/EmptyState.jsx
+++ b/glancy-site/src/components/ui/EmptyState/EmptyState.jsx
@@ -1,0 +1,14 @@
+import styles from './EmptyState.module.css'
+
+function EmptyState({ message, icon, children, className }) {
+  const classes = [styles.container, className].filter(Boolean).join(' ')
+  return (
+    <div className={classes}>
+      {icon && <div className={styles.icon}>{icon}</div>}
+      {message && <div className={styles.message}>{message}</div>}
+      {children}
+    </div>
+  )
+}
+
+export default EmptyState

--- a/glancy-site/src/components/ui/EmptyState/EmptyState.module.css
+++ b/glancy-site/src/components/ui/EmptyState/EmptyState.module.css
@@ -1,0 +1,16 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon {
+  margin-bottom: 1rem;
+}
+
+.message {
+  margin-bottom: 1rem;
+}

--- a/glancy-site/src/components/ui/EmptyState/index.js
+++ b/glancy-site/src/components/ui/EmptyState/index.js
@@ -1,0 +1,1 @@
+export { default } from './EmptyState'

--- a/glancy-site/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
+++ b/glancy-site/src/components/ui/HistoryDisplay/HistoryDisplay.jsx
@@ -1,14 +1,11 @@
 import { useHistory } from '@/context'
+import EmptyState from '@/components/ui/EmptyState'
 import styles from './HistoryDisplay.module.css'
 
-function HistoryDisplay() {
+function HistoryDisplay({ emptyMessage = 'No history' }) {
   const { history } = useHistory()
   if (!history.length) {
-    return (
-      <div className="display-content">
-        <div className="display-term">No history</div>
-      </div>
-    )
+    return <EmptyState message={emptyMessage} />
   }
   return (
     <ul className={styles['history-grid-display']}>

--- a/glancy-site/src/i18n/en.js
+++ b/glancy-site/src/i18n/en.js
@@ -66,6 +66,7 @@ export default {
     searchHistory: 'History',
     noFavorites: "No favorites yet",
     noDefinition: 'No definition',
+    noHistory: 'No history yet',
     clearHistory: 'Clear History',
     notifications: 'Notifications',
     markRead: 'Mark read',

--- a/glancy-site/src/i18n/zh.js
+++ b/glancy-site/src/i18n/zh.js
@@ -66,6 +66,7 @@ export default {
     searchHistory: '搜索记录',
     noDefinition: '暂无释义',
     noFavorites: '暂无收藏',
+    noHistory: '暂无记录',
     clearHistory: '清空记录',
     notifications: '通知',
     markRead: '标为已读',

--- a/glancy-site/src/pages/App/App.css
+++ b/glancy-site/src/pages/App/App.css
@@ -61,19 +61,6 @@
   text-align: center;
 }
 
-.display-content {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  flex: 1;
-  align-items: center;
-  justify-content: center;
-}
-
-.display-term {
-  margin-bottom: 1rem;
-}
-
 
 .chatbox {
   display: flex;

--- a/glancy-site/src/pages/App/FavoritesView.jsx
+++ b/glancy-site/src/pages/App/FavoritesView.jsx
@@ -1,12 +1,9 @@
 import ListItem from '@/components/ui/ListItem'
+import EmptyState from '@/components/ui/EmptyState'
 
 function FavoritesView({ favorites = [], onSelect, onUnfavorite, emptyMessage }) {
   if (!favorites.length) {
-    return (
-      <div className="display-content">
-        <div className="display-term">{emptyMessage}</div>
-      </div>
-    )
+    return <EmptyState message={emptyMessage} />
   }
 
   return (

--- a/glancy-site/src/pages/App/index.jsx
+++ b/glancy-site/src/pages/App/index.jsx
@@ -15,6 +15,7 @@ import { useModelStore } from '@/store'
 import ICP from '@/components/ui/ICP'
 import FavoritesView from './FavoritesView.jsx'
 import { useAppShortcuts } from '@/hooks/useAppShortcuts.js'
+import EmptyState from '@/components/ui/EmptyState'
 
 function App() {
   const [text, setText] = useState('')
@@ -183,15 +184,13 @@ function App() {
               emptyMessage={t.noFavorites}
             />
           ) : showHistory ? (
-            <HistoryDisplay />
+            <HistoryDisplay emptyMessage={t.noHistory} />
           ) : loading ? (
             '...'
           ) : entry ? (
             <DictionaryEntry entry={entry} />
           ) : (
-            <div className="display-content">
-              <div className="display-term">{placeholder}</div>
-            </div>
+            <EmptyState message={placeholder} />
           )}
         </div>
       </Layout>


### PR DESCRIPTION
### Summary
- Introduced reusable EmptyState component with optional icon slot
- Refactored favorites, history, and main view to use EmptyState with localized messages

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run lint:css` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6892ec17c9188332a79f3603e84b8b94