### PR TITLE
[refactor] consolidate auth form configuration

### DIFF
--- a/glancy-site/src/pages/auth/Login/index.jsx
+++ b/glancy-site/src/pages/auth/Login/index.jsx
@@ -4,6 +4,7 @@ import { API_PATHS } from '@/config/api.js'
 import { useUser } from '@/context'
 import { useApi } from '@/hooks/useApi.js'
 import { useLanguage } from '@/context'
+import { useAuthFormConfig } from '../useAuthFormConfig.js'
 
 function Login() {
   const { setUser } = useUser()
@@ -20,14 +21,9 @@ function Login() {
     navigate('/')
   }
 
-  const placeholders = {
-    phone: t.phonePlaceholder,
-    email: t.emailPlaceholder,
-    username: t.usernamePlaceholder
-  }
-
-  const formMethods = ['phone', 'email', 'username']
-  const methodOrder = ['username', 'email', 'phone', 'wechat', 'apple', 'google']
+  const { placeholders, formMethods, methodOrder } = useAuthFormConfig({
+    includeUsername: true
+  })
 
   return (
     <AuthForm

--- a/glancy-site/src/pages/auth/Register/index.jsx
+++ b/glancy-site/src/pages/auth/Register/index.jsx
@@ -4,6 +4,7 @@ import { API_PATHS } from '@/config/api.js'
 import { useApi } from '@/hooks/useApi.js'
 import { useUser } from '@/context'
 import { useLanguage } from '@/context'
+import { useAuthFormConfig } from '../useAuthFormConfig.js'
 
 function Register() {
   const api = useApi()
@@ -37,13 +38,7 @@ function Register() {
     navigate('/')
   }
 
-  const placeholders = {
-    phone: t.phonePlaceholder,
-    email: t.emailPlaceholder
-  }
-
-  const formMethods = ['phone', 'email']
-  const methodOrder = ['phone', 'email', 'wechat', 'apple', 'google']
+  const { placeholders, formMethods, methodOrder } = useAuthFormConfig()
 
   return (
     <AuthForm

--- a/glancy-site/src/pages/auth/useAuthFormConfig.js
+++ b/glancy-site/src/pages/auth/useAuthFormConfig.js
@@ -1,0 +1,22 @@
+import { useLanguage } from '@/context'
+
+export function useAuthFormConfig({ includeUsername = false } = {}) {
+  const { t } = useLanguage()
+
+  const placeholders = {
+    phone: t.phonePlaceholder,
+    email: t.emailPlaceholder,
+    ...(includeUsername && { username: t.usernamePlaceholder })
+  }
+
+  const formMethods = includeUsername
+    ? ['phone', 'email', 'username']
+    : ['phone', 'email']
+
+  const methodOrder = includeUsername
+    ? ['username', 'email', 'phone', 'wechat', 'apple', 'google']
+    : ['phone', 'email', 'wechat', 'apple', 'google']
+
+  return { placeholders, formMethods, methodOrder }
+}
+


### PR DESCRIPTION
### Summary
- Extract shared auth form placeholders and methods into `useAuthFormConfig`.
- Update Login and Register pages to consume the shared config.

### Testing
- `npm ci` ✅
- `npm run lint` ✅
- `npm run build` ✅


------
https://chatgpt.com/codex/tasks/task_e_6892eb4f8b2c8332acf842f27bad64de