### PR TITLE
[refactor] split language and model utilities

### DIFF
--- a/glancy-site/src/utils/__tests__/language.test.js
+++ b/glancy-site/src/utils/__tests__/language.test.js
@@ -1,0 +1,16 @@
+import { detectWordLanguage } from '../language.js'
+import { detectWordLanguage as detectWordLanguageFromIndex } from '../index.js'
+
+describe('detectWordLanguage', () => {
+  test('identifies Chinese text', () => {
+    expect(detectWordLanguage('汉字')).toBe('CHINESE')
+  })
+
+  test('identifies English text', () => {
+    expect(detectWordLanguage('hello')).toBe('ENGLISH')
+  })
+
+  test('is exported via index', () => {
+    expect(detectWordLanguageFromIndex('hello')).toBe('ENGLISH')
+  })
+})

--- a/glancy-site/src/utils/__tests__/model.test.js
+++ b/glancy-site/src/utils/__tests__/model.test.js
@@ -1,0 +1,16 @@
+import { clientNameFromModel } from '../model.js'
+import { clientNameFromModel as clientNameFromModelFromIndex } from '../index.js'
+
+describe('clientNameFromModel', () => {
+  test('extracts client name in lowercase', () => {
+    expect(clientNameFromModel('GPT_3.5')).toBe('gpt')
+  })
+
+  test('returns empty string for falsy model', () => {
+    expect(clientNameFromModel()).toBe('')
+  })
+
+  test('is exported via index', () => {
+    expect(clientNameFromModelFromIndex('BERT_LARGE')).toBe('bert')
+  })
+})

--- a/glancy-site/src/utils/index.js
+++ b/glancy-site/src/utils/index.js
@@ -2,11 +2,5 @@ export { extractMessage, safeJSONParse } from './json.js'
 export { getModifierKey, useIsMobile } from './device.js'
 export { isPresignedUrl, cacheBust } from './url.js'
 export { withStopPropagation } from './stopPropagation.js'
-
-export function detectWordLanguage(text) {
-  return /[\u4e00-\u9fff]/.test(text) ? 'CHINESE' : 'ENGLISH'
-}
-
-export function clientNameFromModel(model) {
-  return model ? model.toLowerCase().replace(/_.*/, '') : ''
-}
+export { detectWordLanguage } from './language.js'
+export { clientNameFromModel } from './model.js'

--- a/glancy-site/src/utils/language.js
+++ b/glancy-site/src/utils/language.js
@@ -1,0 +1,5 @@
+const CHINESE_CHAR_REGEX = /[\u4e00-\u9fff]/
+
+export function detectWordLanguage(text) {
+  return CHINESE_CHAR_REGEX.test(text) ? 'CHINESE' : 'ENGLISH'
+}

--- a/glancy-site/src/utils/model.js
+++ b/glancy-site/src/utils/model.js
@@ -1,0 +1,3 @@
+export function clientNameFromModel(model) {
+  return model ? model.toLowerCase().replace(/_.*/, '') : ''
+}


### PR DESCRIPTION
### Summary
- move language detection and model client helpers into dedicated modules and re-export via utils index
- add unit tests covering the new utilities

### Testing
- `npm run lint` ✅
- `npm test` ❌ (fails: The requested module '@/context' does not provide an export named 'useLocale')
- `npm run build` ✅

### Notes
- test suite hits unrelated module resolution errors and OOM


------
https://chatgpt.com/codex/tasks/task_e_6892ebdb20048332a4416f8888c6248a