### PR TITLE
[feature] add pickState util for persisted stores

### DIFF
--- a/glancy-site/src/store/favoritesStore.ts
+++ b/glancy-site/src/store/favoritesStore.ts
@@ -1,4 +1,5 @@
 import { createPersistentStore } from './createPersistentStore.ts'
+import { pickState } from './persistUtils.ts'
 
 interface FavoritesState {
   favorites: string[]
@@ -18,6 +19,6 @@ export const useFavoritesStore = createPersistentStore<FavoritesState>({
     }
   }),
   persistOptions: {
-    partialize: (state) => ({ favorites: state.favorites })
+    partialize: pickState(['favorites'])
   }
 })

--- a/glancy-site/src/store/historyStore.ts
+++ b/glancy-site/src/store/historyStore.ts
@@ -1,5 +1,6 @@
 import api from '@/api/index.js'
 import { createPersistentStore } from './createPersistentStore.ts'
+import { pickState } from './persistUtils.ts'
 import type { User } from './userStore.ts'
 
 interface HistoryState {
@@ -124,6 +125,6 @@ export const useHistoryStore = createPersistentStore<HistoryState>({
     }
   },
   persistOptions: {
-    partialize: (state) => ({ history: state.history })
+    partialize: pickState(['history'])
   }
 })

--- a/glancy-site/src/store/modelStore.ts
+++ b/glancy-site/src/store/modelStore.ts
@@ -1,4 +1,5 @@
 import { createPersistentStore } from './createPersistentStore.ts'
+import { pickState } from './persistUtils.ts'
 
 interface ModelState {
   model: string
@@ -14,6 +15,6 @@ export const useModelStore = createPersistentStore<ModelState>({
     }
   }),
   persistOptions: {
-    partialize: (state) => ({ model: state.model })
+    partialize: pickState(['model'])
   }
 })

--- a/glancy-site/src/store/persistUtils.ts
+++ b/glancy-site/src/store/persistUtils.ts
@@ -1,0 +1,9 @@
+export function pickState<T extends object, K extends keyof T>(keys: K[]) {
+  return (state: T) => {
+    const result = {} as Pick<T, K>
+    for (const key of keys) {
+      result[key] = state[key]
+    }
+    return result
+  }
+}

--- a/glancy-site/src/store/userStore.ts
+++ b/glancy-site/src/store/userStore.ts
@@ -1,4 +1,5 @@
 import { createPersistentStore } from './createPersistentStore.ts'
+import { pickState } from './persistUtils.ts'
 
 export interface User {
   id: string
@@ -25,6 +26,6 @@ export const useUserStore = createPersistentStore<UserState>({
     }
   }),
   persistOptions: {
-    partialize: (state) => ({ user: state.user })
+    partialize: pickState(['user'])
   }
 })


### PR DESCRIPTION
### Summary
- Introduced generic `pickState` to build typed `partialize` helpers.
- Refactored favorites, history, model, and user stores to use `pickState` for persistence.

### Testing
- `npm run lint` ✅
- `npm run build` ✅

------
https://chatgpt.com/codex/tasks/task_e_68935c2e06248332a99a937041889af7